### PR TITLE
Feature/22 article view create api

### DIFF
--- a/src/main/java/com/team03/monew/controller/NewsArticleController.java
+++ b/src/main/java/com/team03/monew/controller/NewsArticleController.java
@@ -1,0 +1,29 @@
+package com.team03.monew.controller;
+
+import com.team03.monew.dto.newsArticle.ArticleViewDto;
+import com.team03.monew.service.NewsArticleService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/articles")
+@RequiredArgsConstructor
+public class NewsArticleController {
+
+    private final NewsArticleService newsArticleService;
+
+    @PostMapping("/{articleId}/article-views")
+    public ResponseEntity<ArticleViewDto> saveArticleView(
+        @PathVariable UUID articleId,
+        @RequestHeader("MoNew-Request-User-ID") UUID userId
+    ) {
+        ArticleViewDto dto = newsArticleService.saveArticleView(articleId, userId);
+        return ResponseEntity.ok(dto);
+    }
+}

--- a/src/main/java/com/team03/monew/dto/newsArticle/ArticleDto.java
+++ b/src/main/java/com/team03/monew/dto/newsArticle/ArticleDto.java
@@ -1,0 +1,16 @@
+package com.team03.monew.dto.newsArticle;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ArticleDto(
+    UUID id,
+    String source,
+    String sourceUrl,
+    String title,
+    LocalDateTime publishDate,
+    String summary,
+    int commentCount,
+    int viewCount,
+    boolean viewedByMe
+) {}

--- a/src/main/java/com/team03/monew/dto/newsArticle/ArticleRestoreResultDto.java
+++ b/src/main/java/com/team03/monew/dto/newsArticle/ArticleRestoreResultDto.java
@@ -1,0 +1,10 @@
+package com.team03.monew.dto.newsArticle;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ArticleRestoreResultDto(
+    LocalDateTime restoreDate,
+    List<String> restoredArticleIds,
+    int restoredArticleCount
+) {}

--- a/src/main/java/com/team03/monew/dto/newsArticle/ArticleViewDto.java
+++ b/src/main/java/com/team03/monew/dto/newsArticle/ArticleViewDto.java
@@ -1,0 +1,18 @@
+package com.team03.monew.dto.newsArticle;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ArticleViewDto(
+    UUID id,
+    UUID viewedBy,
+    LocalDateTime createdAt,
+    UUID articleId,
+    String source,
+    String sourceUrl,
+    String articleTitle,
+    LocalDateTime articlePublishedDate,
+    String articleSummary,
+    int articleCommentCount,
+    int articleViewCount
+) {}

--- a/src/main/java/com/team03/monew/dto/newsArticle/CursorPageResponseArticleDto.java
+++ b/src/main/java/com/team03/monew/dto/newsArticle/CursorPageResponseArticleDto.java
@@ -1,0 +1,13 @@
+package com.team03.monew.dto.newsArticle;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CursorPageResponseArticleDto(
+    List<ArticleDto> content,
+    String nextCursor,
+    LocalDateTime nextAfter,
+    int size,
+    long totalElements,
+    boolean hasNext
+) {}

--- a/src/main/java/com/team03/monew/dto/newsArticle/mapper/ArticleViewMapper.java
+++ b/src/main/java/com/team03/monew/dto/newsArticle/mapper/ArticleViewMapper.java
@@ -1,0 +1,25 @@
+package com.team03.monew.dto.newsArticle.mapper;
+
+import com.team03.monew.dto.newsArticle.ArticleViewDto;
+import com.team03.monew.entity.ArticleView;
+import com.team03.monew.entity.NewsArticle;
+
+public class ArticleViewMapper {
+
+    public static ArticleViewDto toDto(ArticleView view) {
+        NewsArticle a = view.getArticle();
+        return new ArticleViewDto(
+            view.getId(),
+            view.getUserId(),
+            view.getCreatedAt(),
+            a.getId(),
+            a.getSource(),
+            a.getOriginalLink(),
+            a.getTitle(),
+            a.getDate(),
+            a.getSummary(),
+            a.getComments().size(),
+            a.getViewCount()
+        );
+    }
+}

--- a/src/main/java/com/team03/monew/dto/newsArticle/mapper/NewsArticleMapper.java
+++ b/src/main/java/com/team03/monew/dto/newsArticle/mapper/NewsArticleMapper.java
@@ -1,0 +1,22 @@
+package com.team03.monew.dto.newsArticle.mapper;
+
+import com.team03.monew.dto.newsArticle.ArticleDto;
+import com.team03.monew.entity.NewsArticle;
+
+public class NewsArticleMapper {
+
+    public static ArticleDto toArticleDto(NewsArticle news) {
+        return new ArticleDto(
+            news.getId(),
+            news.getSource(),
+            news.getOriginalLink(),             // sourceUrl
+            news.getTitle(),
+            news.getDate(),                     // publishDate
+            news.getSummary(),
+            news.getComments().size(),          // commentCount
+            news.getViewCount(),
+            false                                // viewedByMe (기본값 false)
+        );
+    }
+
+}

--- a/src/main/java/com/team03/monew/entity/ArticleView.java
+++ b/src/main/java/com/team03/monew/entity/ArticleView.java
@@ -1,0 +1,45 @@
+package com.team03.monew.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Table;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "article_views", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"article_id", "userId"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArticleView {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id", nullable = false)
+    private NewsArticle article;
+
+    @Column(nullable = false)
+    private UUID userId;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    public ArticleView(NewsArticle article, UUID userId) {
+        this.article = article;
+        this.userId = userId;
+    }
+}
+

--- a/src/main/java/com/team03/monew/entity/NewsArticle.java
+++ b/src/main/java/com/team03/monew/entity/NewsArticle.java
@@ -61,5 +61,9 @@ public class NewsArticle {
     comment.setNews(null);
   }
 
+  public void increaseViewCount() {
+    this.viewCount++;
+  }
+
   // getter/setter
 }

--- a/src/main/java/com/team03/monew/repository/ArticleViewRepository.java
+++ b/src/main/java/com/team03/monew/repository/ArticleViewRepository.java
@@ -1,0 +1,10 @@
+package com.team03.monew.repository;
+
+import com.team03.monew.entity.ArticleView;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID> {
+    Optional<ArticleView> findByArticleIdAndUserId(UUID articleId, UUID userId);
+}

--- a/src/main/java/com/team03/monew/repository/NewsArticleRepository.java
+++ b/src/main/java/com/team03/monew/repository/NewsArticleRepository.java
@@ -1,32 +1,12 @@
 package com.team03.monew.repository;
 
 import com.team03.monew.entity.NewsArticle;
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface NewsArticleRepository extends JpaRepository<NewsArticle, UUID> {
-  // 제목 또는 요약에서 키워드 검색 (부분 일치)
-//  @Query("SELECT n FROM NewsArticle n WHERE n.deleted = false AND (n.title LIKE %:keyword% OR n.summary LIKE %:keyword%)")
-//  List<NewsArticle> searchByTitleOrSummary(@Param("keyword") String keyword);
-//
-//  // 출처, 관심사, 날짜 모두 만족하는 경우 검색
-//  List<NewsArticle> findAllByDeletedFalseAndSourceAndInterestIdAndDate(
-//      String source, UUID interestId, LocalDateTime date
-//  );
-//
-//  // 내림차순 정렬 및 페이지네이션, 날짜, 조회 수, 댓글 수
-//  Slice<NewsArticle> findByDeletedFalseAndDateBeforeOrderByDateDesc(LocalDateTime cursor, Pageable pageable);
-//  Slice<NewsArticle> findByDeletedFalseAndViewCountLessThanOrderByViewCountDesc(int cursor, Pageable pageable);
-//  Slice<NewsArticle> findByDeletedFalseAndCommentsSizeLessThanOrderByCommentsSizeDesc(int cursor, Pageable pageable);
-//
-//  // 날짜 단위로 데이터 백업
-//  List<NewsArticle> findAllByDateBetweenAndDeletedFalse(LocalDateTime start, LocalDateTime end);
+    // 삭제되지 않은 기사만 찾기. 논리 삭제 처리된 데이터 제외하고 조회
+    Optional<NewsArticle> findByIdAndDeletedFalse(UUID id);
 
 }

--- a/src/main/java/com/team03/monew/service/NewsArticleService.java
+++ b/src/main/java/com/team03/monew/service/NewsArticleService.java
@@ -1,0 +1,41 @@
+package com.team03.monew.service;
+
+import com.team03.monew.dto.newsArticle.ArticleViewDto;
+import com.team03.monew.dto.newsArticle.mapper.ArticleViewMapper;
+import com.team03.monew.entity.ArticleView;
+import com.team03.monew.entity.NewsArticle;
+import com.team03.monew.exception.CustomException;
+import com.team03.monew.exception.ErrorCode;
+import com.team03.monew.exception.ErrorDetail;
+import com.team03.monew.exception.ExceptionType;
+import com.team03.monew.repository.ArticleViewRepository;
+import com.team03.monew.repository.NewsArticleRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NewsArticleService {
+
+    private final NewsArticleRepository newsRepository;
+    private final ArticleViewRepository articleViewRepository;
+
+    public ArticleViewDto saveArticleView(UUID articleId, UUID userId) {
+        NewsArticle article = newsRepository.findByIdAndDeletedFalse(articleId)
+            .orElseThrow(() ->{
+                ErrorDetail detail = new ErrorDetail("UUID", "articleId", articleId.toString());
+                return new CustomException(ErrorCode.RESOURCE_NOT_FOUND, detail, ExceptionType.NEWSARTICLE);
+            });
+
+        Optional<ArticleView> optional = articleViewRepository.findByArticleIdAndUserId(articleId, userId);
+        if (optional.isPresent()) {
+            return ArticleViewMapper.toDto(optional.get());
+        }
+
+        ArticleView view = articleViewRepository.save(new ArticleView(article, userId));
+        article.increaseViewCount();
+        return ArticleViewMapper.toDto(view);
+    }
+}

--- a/src/test/java/com/team03/monew/controller/NewsArticleControllerTest.java
+++ b/src/test/java/com/team03/monew/controller/NewsArticleControllerTest.java
@@ -1,0 +1,87 @@
+package com.team03.monew.controller;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team03.monew.dto.newsArticle.ArticleViewDto;
+import com.team03.monew.exception.CustomException;
+import com.team03.monew.exception.ErrorCode;
+import com.team03.monew.exception.ErrorDetail;
+import com.team03.monew.exception.ExceptionType;
+import com.team03.monew.service.NewsArticleService;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = NewsArticleController.class)
+class NewsArticleControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private NewsArticleService newsArticleService;
+
+    @Test
+    @DisplayName("기사 뷰 등록 성공")
+    void saveArticleView_Success() throws Exception {
+        // Given
+        UUID articleId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        ArticleViewDto dto = new ArticleViewDto(
+            UUID.randomUUID(),         // viewId
+            userId,                    // viewedBy
+            LocalDateTime.now(),       // createdAt
+            articleId,                 // articleId
+            "NAVER",                   // source
+            "https://naver.com/article", // sourceUrl
+            "기사 제목입니다",            // articleTitle
+            LocalDateTime.now(),       // articlePublishedDate
+            "기사 요약입니다",           // articleSummary
+            5,                         // commentCount
+            100                        // viewCount
+        );
+
+        given(newsArticleService.saveArticleView(eq(articleId), eq(userId)))
+            .willReturn(dto);
+
+        // When & Then
+        mockMvc.perform(post("/api/articles/{articleId}/article-views", articleId)
+                .header("MoNew-Request-User-ID", userId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.articleId").value(articleId.toString()))
+            .andExpect(jsonPath("$.viewedBy").value(userId.toString()))
+            .andExpect(jsonPath("$.articleTitle").value("기사 제목입니다"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 뉴스 기사 ID로 조회 시 404 응답")
+    void saveArticleView_NotFound() throws Exception {
+        // Given
+        UUID articleId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        ErrorDetail detail = new ErrorDetail("UUID", "articleId", articleId.toString());
+
+        given(newsArticleService.saveArticleView(eq(articleId), eq(userId)))
+            .willThrow(new CustomException(ErrorCode.RESOURCE_NOT_FOUND, detail, ExceptionType.NEWSARTICLE));
+
+        // When & Then
+        mockMvc.perform(post("/api/articles/{articleId}/article-views", articleId)
+                .header("MoNew-Request-User-ID", userId))
+            .andExpect(status().isNotFound());
+    }
+
+}


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #22 

---

## 📌 작업 개요
<!-- 어떤 작업을 했는지 간단하게 요약해주세요 -->
- 기사 뷰 등록 API 구현 및 관련 구성 추가

---

## 🛠 작업 상세 내용
<!-- 주요 작업 내용을 리스트로 정리해주세요 -->
- 사용자의 뉴스 기사 1회 조회 이력 저장을 위한 ArticleView 엔티티 추가
- ArticleViewMapper, Repository, Service 구성
- NewsArticleController에 /{articleId}/article-views POST 엔드포인트 구현
- 중복 조회 방지를 위한 viewCount 증가 로직 포함
- NewsArticle 엔티티 및 레포지토리에 관련 메서드 보완
- 기사 뷰 등록 API 단위 테스트 추가
