### PR TITLE
Feature/30 뉴스 기사 목록 조회 관련 api 구현

### DIFF
--- a/src/main/java/com/team03/monew/controller/NewsArticleController.java
+++ b/src/main/java/com/team03/monew/controller/NewsArticleController.java
@@ -1,14 +1,25 @@
 package com.team03.monew.controller;
 
-import com.team03.monew.dto.newsArticle.ArticleViewDto;
+import com.team03.monew.dto.newsArticle.response.ArticleViewDto;
+import com.team03.monew.dto.newsArticle.response.CursorPageResponseArticleDto;
+import com.team03.monew.exception.CustomException;
+import com.team03.monew.exception.ErrorCode;
+import com.team03.monew.exception.ErrorDetail;
+import com.team03.monew.exception.ExceptionType;
 import com.team03.monew.service.NewsArticleService;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,4 +37,47 @@ public class NewsArticleController {
         ArticleViewDto dto = newsArticleService.saveArticleView(articleId, userId);
         return ResponseEntity.ok(dto);
     }
+
+    @GetMapping
+    public ResponseEntity<CursorPageResponseArticleDto> getArticles(
+        @RequestParam(required = false) String keyword,
+        @RequestParam(required = false) UUID interestId,
+        @RequestParam(required = false) List<String> sourceIn,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime publishDateFrom,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime publishDateTo,
+        @RequestParam String orderBy,
+        @RequestParam String direction,
+        @RequestParam(required = false) String cursor,
+        @RequestParam(required = false) String after,
+        @RequestParam(defaultValue = "50") Integer limit,
+        @RequestHeader("Monew-Request-User-ID") UUID requestUserId
+    ){
+        validateOrderBy(orderBy);
+        validateDirection(direction);
+
+        CursorPageResponseArticleDto result = newsArticleService.searchArticles(
+            keyword, interestId, sourceIn, publishDateFrom, publishDateTo,
+            orderBy, direction, cursor, after, limit, requestUserId
+        );
+        return ResponseEntity.ok(result);
+    }
+
+    private static final Set<String> VALID_ORDER_BY = Set.of("publishDate", "commentCount", "viewCount");
+    private static final Set<String> VALID_DIRECTION = Set.of("ASC", "DESC");
+
+
+    private void validateOrderBy(String orderBy) {
+        if (!VALID_ORDER_BY.contains(orderBy)) {
+            ErrorDetail detail = new ErrorDetail("String", "orderBy", orderBy);
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, detail, ExceptionType.NEWSARTICLE);
+        }
+    }
+
+    private void validateDirection(String direction) {
+        if (!VALID_DIRECTION.contains(direction.toUpperCase())) {
+            ErrorDetail detail = new ErrorDetail("String", "direction", direction);
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, detail, ExceptionType.NEWSARTICLE);
+        }
+    }
+
 }

--- a/src/main/java/com/team03/monew/dto/newsArticle/mapper/ArticleViewMapper.java
+++ b/src/main/java/com/team03/monew/dto/newsArticle/mapper/ArticleViewMapper.java
@@ -1,6 +1,6 @@
 package com.team03.monew.dto.newsArticle.mapper;
 
-import com.team03.monew.dto.newsArticle.ArticleViewDto;
+import com.team03.monew.dto.newsArticle.response.ArticleViewDto;
 import com.team03.monew.entity.ArticleView;
 import com.team03.monew.entity.NewsArticle;
 

--- a/src/main/java/com/team03/monew/dto/newsArticle/mapper/NewsArticleMapper.java
+++ b/src/main/java/com/team03/monew/dto/newsArticle/mapper/NewsArticleMapper.java
@@ -1,6 +1,6 @@
 package com.team03.monew.dto.newsArticle.mapper;
 
-import com.team03.monew.dto.newsArticle.ArticleDto;
+import com.team03.monew.dto.newsArticle.response.ArticleDto;
 import com.team03.monew.entity.NewsArticle;
 
 public class NewsArticleMapper {

--- a/src/main/java/com/team03/monew/dto/newsArticle/response/ArticleDto.java
+++ b/src/main/java/com/team03/monew/dto/newsArticle/response/ArticleDto.java
@@ -1,4 +1,4 @@
-package com.team03.monew.dto.newsArticle;
+package com.team03.monew.dto.newsArticle.response;
 
 import java.time.LocalDateTime;
 import java.util.UUID;

--- a/src/main/java/com/team03/monew/dto/newsArticle/response/ArticleViewDto.java
+++ b/src/main/java/com/team03/monew/dto/newsArticle/response/ArticleViewDto.java
@@ -1,4 +1,4 @@
-package com.team03.monew.dto.newsArticle;
+package com.team03.monew.dto.newsArticle.response;
 
 import java.time.LocalDateTime;
 import java.util.UUID;

--- a/src/main/java/com/team03/monew/dto/newsArticle/response/CursorPageResponseArticleDto.java
+++ b/src/main/java/com/team03/monew/dto/newsArticle/response/CursorPageResponseArticleDto.java
@@ -1,4 +1,4 @@
-package com.team03.monew.dto.newsArticle;
+package com.team03.monew.dto.newsArticle.response;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/team03/monew/repository/NewsArticleRepository.java
+++ b/src/main/java/com/team03/monew/repository/NewsArticleRepository.java
@@ -1,12 +1,13 @@
 package com.team03.monew.repository;
 
 import com.team03.monew.entity.NewsArticle;
+import com.team03.monew.repository.custom.NewsArticleRepositoryCustom;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface NewsArticleRepository extends JpaRepository<NewsArticle, UUID> {
+public interface NewsArticleRepository extends JpaRepository<NewsArticle, UUID>,
+    NewsArticleRepositoryCustom {
     // 삭제되지 않은 기사만 찾기. 논리 삭제 처리된 데이터 제외하고 조회
     Optional<NewsArticle> findByIdAndDeletedFalse(UUID id);
-
 }

--- a/src/main/java/com/team03/monew/repository/custom/NewsArticleRepositoryCustom.java
+++ b/src/main/java/com/team03/monew/repository/custom/NewsArticleRepositoryCustom.java
@@ -1,0 +1,20 @@
+package com.team03.monew.repository.custom;
+
+import com.team03.monew.entity.NewsArticle;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public interface NewsArticleRepositoryCustom {
+    List<NewsArticle> searchArticles(
+        String keyword,
+        UUID interestId,
+        List<String> sourceIn,
+        LocalDateTime publishDateFrom,
+        LocalDateTime publishDateTo,
+        String orderBy,
+        String direction,
+        String after,
+        int limit
+    );
+}

--- a/src/main/java/com/team03/monew/repository/impl/NewsArticleRepositoryImpl.java
+++ b/src/main/java/com/team03/monew/repository/impl/NewsArticleRepositoryImpl.java
@@ -1,0 +1,83 @@
+package com.team03.monew.repository.impl;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team03.monew.entity.NewsArticle;
+import com.team03.monew.entity.QNewsArticle;
+import com.team03.monew.exception.CustomException;
+import com.team03.monew.exception.ErrorCode;
+import com.team03.monew.exception.ErrorDetail;
+import com.team03.monew.exception.ExceptionType;
+import com.team03.monew.repository.custom.NewsArticleRepositoryCustom;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NewsArticleRepositoryImpl implements NewsArticleRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<NewsArticle> searchArticles(
+        String keyword,
+        UUID interestId,
+        List<String> sourceIn,
+        LocalDateTime publishDateFrom,
+        LocalDateTime publishDateTo,
+        String orderBy,
+        String direction,
+        String after,
+        int limit
+    ) {
+        QNewsArticle article = QNewsArticle.newsArticle;
+        BooleanBuilder condition = new BooleanBuilder();
+        condition.and(article.deleted.isFalse());
+
+        if (keyword != null && !keyword.isBlank()) {
+            condition.and(article.title.containsIgnoreCase(keyword)
+                .or(article.summary.containsIgnoreCase(keyword)));
+        }
+        if (interestId != null) {
+            condition.and(article.interest.id.eq(interestId));
+        }
+        if (sourceIn != null && !sourceIn.isEmpty()) {
+            condition.and(article.source.in(sourceIn));
+        }
+        if (publishDateFrom != null) {
+            condition.and(article.date.goe(publishDateFrom));
+        }
+        if (publishDateTo != null) {
+            condition.and(article.date.loe(publishDateTo));
+        }
+        if (after != null) {
+            condition.and(article.date.lt(LocalDateTime.parse(after)));
+        }
+
+        OrderSpecifier<?> orderSpecifier = getOrderSpecifier(orderBy, direction);
+
+        return queryFactory
+            .selectFrom(article)
+            .where(condition)
+            .orderBy(orderSpecifier)
+            .limit(limit + 1)
+            .fetch();
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(String orderBy, String direction) {
+        QNewsArticle article = QNewsArticle.newsArticle;
+        Order order = direction.equalsIgnoreCase("ASC") ? Order.ASC : Order.DESC;
+
+        return switch (orderBy) {
+            case "date" -> new OrderSpecifier<>(order, article.date);
+            case "commentCount" -> new OrderSpecifier<>(order, article.comments.size());
+            case "viewCount" -> new OrderSpecifier<>(order, article.viewCount);
+            default -> throw new CustomException(ErrorCode.INVALID_TYPE_VALUE, new ErrorDetail("date, commentCount, vieCount", "orderBy", orderBy), ExceptionType.NEWSARTICLE);
+        };
+    }
+}

--- a/src/main/java/com/team03/monew/service/NewsArticleService.java
+++ b/src/main/java/com/team03/monew/service/NewsArticleService.java
@@ -1,7 +1,11 @@
 package com.team03.monew.service;
 
-import com.team03.monew.dto.newsArticle.ArticleViewDto;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team03.monew.dto.newsArticle.response.ArticleDto;
+import com.team03.monew.dto.newsArticle.response.ArticleViewDto;
+import com.team03.monew.dto.newsArticle.response.CursorPageResponseArticleDto;
 import com.team03.monew.dto.newsArticle.mapper.ArticleViewMapper;
+import com.team03.monew.dto.newsArticle.mapper.NewsArticleMapper;
 import com.team03.monew.entity.ArticleView;
 import com.team03.monew.entity.NewsArticle;
 import com.team03.monew.exception.CustomException;
@@ -10,20 +14,27 @@ import com.team03.monew.exception.ErrorDetail;
 import com.team03.monew.exception.ExceptionType;
 import com.team03.monew.repository.ArticleViewRepository;
 import com.team03.monew.repository.NewsArticleRepository;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class NewsArticleService {
 
-    private final NewsArticleRepository newsRepository;
+    private final NewsArticleRepository newsArticleRepository;
     private final ArticleViewRepository articleViewRepository;
+    private final JPAQueryFactory queryFactory;
 
+    @Transactional
     public ArticleViewDto saveArticleView(UUID articleId, UUID userId) {
-        NewsArticle article = newsRepository.findByIdAndDeletedFalse(articleId)
+        NewsArticle article = newsArticleRepository.findByIdAndDeletedFalse(articleId)
             .orElseThrow(() ->{
                 ErrorDetail detail = new ErrorDetail("UUID", "articleId", articleId.toString());
                 return new CustomException(ErrorCode.RESOURCE_NOT_FOUND, detail, ExceptionType.NEWSARTICLE);
@@ -38,4 +49,48 @@ public class NewsArticleService {
         article.increaseViewCount();
         return ArticleViewMapper.toDto(view);
     }
+
+    @Transactional(readOnly = true)
+    public CursorPageResponseArticleDto searchArticles(
+        String keyword,
+        UUID interestId,
+        List<String> sourceIn,
+        LocalDateTime publishDateFrom,
+        LocalDateTime publishDateTo,
+        String orderBy,
+        String direction,
+        String cursor,
+        String after,
+        Integer limit,
+        UUID requestUserId) {
+
+        // Repository에 로직 위임
+        List<NewsArticle> result = newsArticleRepository.searchArticles(
+            keyword, interestId, sourceIn,
+            publishDateFrom, publishDateTo,
+            orderBy, direction, after, limit
+        );
+
+        // 페이지 조정
+        boolean hasNext = result.size() > limit;
+        List<NewsArticle> pageContent = hasNext ? result.subList(0, limit) : result;
+
+        List<ArticleDto> articles = pageContent.stream()
+            .map(NewsArticleMapper::toArticleDto)
+            .toList();
+
+        String nextCursor = hasNext ? encodeCursor(articles.get(articles.size() - 1)) : null;
+        LocalDateTime nextAfter = hasNext ? articles.get(articles.size() - 1).publishDate() : null;
+
+        return new CursorPageResponseArticleDto(articles, nextCursor, nextAfter, limit, result.size(), hasNext);
+    }
+
+    // 마지막 요소의 커서 인코딩
+    public String encodeCursor(ArticleDto lastArticle) {
+        // publishDate 기준
+        return Base64.getEncoder().encodeToString(
+            lastArticle.publishDate().toString().getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
 }


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #30

---

## 📌 작업 개요
- 뉴스 기사 목록 조회 API를 구현  
관심사, 출처, 날짜, 키워드 등의 조건에 따라 필터링 가능하며,  
정렬 조건 및 커서 기반 페이지네이션을 지원합니다.

---

## 🛠 작업 상세 내용
- `/api/articles` GET API 컨트롤러 구현
- 키워드(title, summary) 검색 조건 적용
- 관심사 ID, 출처 목록, 날짜 범위 필터 처리
- 정렬 기준(`publishDate`, `commentCount`, `viewCount`) + 정렬 방향 적용
- 커서 기반 페이지네이션(`after`) 구현
- QueryDSL 기반 검색 조건 구성
- `NewsArticleRepositoryCustom` + `NewsArticleRepositoryImpl` 생성
- 응답 DTO 구조 설계: `CursorPageResponseArticleDto`, `ArticleDto`
- 테스트 코드 작성(MockMvc 기반)

주요 변경 파일
- `NewsArticleController.java`
- `NewsArticleService.java`
- `NewsArticleRepositoryCustom.java`
- `NewsArticleRepositoryImpl.java`
- `ArticleDto.java`, `CursorPageResponseArticleDto.java`
- `NewsArticleMapper.java`
- `NewsArticleControllerTest.java`

---

## 기타 참고 사항
- 현재는 단일 필드(`date`) 기반 `after` 커서로 페이지네이션 처리를 진행하고 있습니다.
- `Monew-Request-User-ID`는 현재 기능 미사용 상태
