### PR TITLE
Feature/39 출처 목록 조회 API 구현 및 테스트 추가

### DIFF
--- a/src/main/java/com/team03/monew/controller/NewsArticleController.java
+++ b/src/main/java/com/team03/monew/controller/NewsArticleController.java
@@ -2,6 +2,7 @@ package com.team03.monew.controller;
 
 import com.team03.monew.dto.newsArticle.response.ArticleViewDto;
 import com.team03.monew.dto.newsArticle.response.CursorPageResponseArticleDto;
+import com.team03.monew.dto.newsArticle.response.SourcesResponseDto;
 import com.team03.monew.exception.CustomException;
 import com.team03.monew.exception.ErrorCode;
 import com.team03.monew.exception.ErrorDetail;
@@ -60,6 +61,11 @@ public class NewsArticleController {
             orderBy, direction, cursor, after, limit, requestUserId
         );
         return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/sources")
+    public ResponseEntity<SourcesResponseDto> getSources() {
+        return ResponseEntity.ok(newsArticleService.getSources());
     }
 
     private static final Set<String> VALID_ORDER_BY = Set.of("publishDate", "commentCount", "viewCount");

--- a/src/main/java/com/team03/monew/dto/newsArticle/response/SourcesResponseDto.java
+++ b/src/main/java/com/team03/monew/dto/newsArticle/response/SourcesResponseDto.java
@@ -1,0 +1,10 @@
+package com.team03.monew.dto.newsArticle.response;
+
+import java.util.List;
+
+// 뉴스 출처 목록 응답용
+public record SourcesResponseDto (
+    List<String> sources
+) {
+
+}

--- a/src/main/java/com/team03/monew/repository/NewsArticleRepository.java
+++ b/src/main/java/com/team03/monew/repository/NewsArticleRepository.java
@@ -2,12 +2,18 @@ package com.team03.monew.repository;
 
 import com.team03.monew.entity.NewsArticle;
 import com.team03.monew.repository.custom.NewsArticleRepositoryCustom;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface NewsArticleRepository extends JpaRepository<NewsArticle, UUID>,
     NewsArticleRepositoryCustom {
     // 삭제되지 않은 기사만 찾기. 논리 삭제 처리된 데이터 제외하고 조회
     Optional<NewsArticle> findByIdAndDeletedFalse(UUID id);
+
+    // 출처 목록 조회용
+    @Query("SELECT DISTINCT n.source FROM NewsArticle n WHERE n.deleted = false")
+    List<String> findDistinctSources();
 }

--- a/src/main/java/com/team03/monew/service/NewsArticleService.java
+++ b/src/main/java/com/team03/monew/service/NewsArticleService.java
@@ -6,6 +6,7 @@ import com.team03.monew.dto.newsArticle.response.ArticleViewDto;
 import com.team03.monew.dto.newsArticle.response.CursorPageResponseArticleDto;
 import com.team03.monew.dto.newsArticle.mapper.ArticleViewMapper;
 import com.team03.monew.dto.newsArticle.mapper.NewsArticleMapper;
+import com.team03.monew.dto.newsArticle.response.SourcesResponseDto;
 import com.team03.monew.entity.ArticleView;
 import com.team03.monew.entity.NewsArticle;
 import com.team03.monew.exception.CustomException;
@@ -83,6 +84,12 @@ public class NewsArticleService {
         LocalDateTime nextAfter = hasNext ? articles.get(articles.size() - 1).publishDate() : null;
 
         return new CursorPageResponseArticleDto(articles, nextCursor, nextAfter, limit, result.size(), hasNext);
+    }
+
+    @Transactional(readOnly = true)
+    public SourcesResponseDto getSources() {
+        List<String> sources = newsArticleRepository.findDistinctSources();
+        return new SourcesResponseDto(sources);
     }
 
     // 마지막 요소의 커서 인코딩

--- a/src/test/java/com/team03/monew/controller/NewsArticleControllerTest.java
+++ b/src/test/java/com/team03/monew/controller/NewsArticleControllerTest.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team03.monew.dto.newsArticle.response.ArticleDto;
 import com.team03.monew.dto.newsArticle.response.ArticleViewDto;
 import com.team03.monew.dto.newsArticle.response.CursorPageResponseArticleDto;
+import com.team03.monew.dto.newsArticle.response.SourcesResponseDto;
 import com.team03.monew.exception.CustomException;
 import com.team03.monew.exception.ErrorCode;
 import com.team03.monew.exception.ErrorDetail;
@@ -114,6 +115,33 @@ class NewsArticleControllerTest {
                 .header("Monew-Request-User-ID", UUID.randomUUID().toString()))
             .andExpect(status().isBadRequest());
     }
+
+    @Test
+    @DisplayName("출처 목록 조회 성공")
+    void getSources_Success() throws Exception {
+        List<String> mockSources = List.of("NAVER", "연합뉴스");
+        given(newsArticleService.getSources())
+            .willReturn(new SourcesResponseDto(mockSources));
+
+        mockMvc.perform(get("/api/articles/sources"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.sources[0]").value("NAVER"))
+            .andExpect(jsonPath("$.sources[1]").value("연합뉴스"));
+    }
+
+    @Test
+    @DisplayName("출처 목록 조회 실패 - 서버 에러 발생 시 500 반환")
+    void getSources_Fail() throws Exception {
+        given(newsArticleService.getSources())
+            .willThrow(new IllegalStateException("DB 연결 오류"));
+
+        mockMvc.perform(get("/api/articles/sources"))
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"))
+            .andExpect(jsonPath("$.exceptionType").value("IllegalStateException"));
+    }
+
+
 
     public static ArticleDto createMockArticle() {
         return new ArticleDto(


### PR DESCRIPTION
- GET /api/articles/sources 엔드포인트 추가
- NewsArticleRepository에 distinct source 조회 쿼리 추가
- SourcesResponseDto 생성
- readOnly 트랜잭션 설정
- 예외 상황에 대한 컨트롤러 테스트 코드 포함

## 🔗 관련 이슈
Closes #39

---

## 📌 작업 개요
- 뉴스 출처 목록 조회 API 구현 및 관련 컨트롤러, 서비스, DTO 작성

---

## 🛠 작업 상세 내용
- GET /api/articles/sources 엔드포인트 추가
- `NewsArticleRepository`에 출처 목록 조회용 JPQL 쿼리 추가
- `SourcesResponseDto` 생성 및 응답 구조 정의
- `NewsArticleService`에 readOnly 트랜잭션 기반 메서드 구현
- 성공/실패 케이스에 대한 컨트롤러 테스트 작성