### PR TITLE
Feature/42 뉴스 기사 물리/논리 삭제 기능 구현

### DIFF
--- a/src/main/java/com/team03/monew/controller/NewsArticleController.java
+++ b/src/main/java/com/team03/monew/controller/NewsArticleController.java
@@ -72,13 +72,17 @@ public class NewsArticleController {
     @DeleteMapping("/{articleId}")
     public ResponseEntity<Void> deleteArticleLogical(@PathVariable UUID articleId) {
         newsArticleService.deleteLogically(articleId);
+        return ResponseEntity.noContent().build();
+    }
 
+    @DeleteMapping("/{articleId}/hard")
+    public ResponseEntity<Void> deleteArticleHard(@PathVariable UUID articleId) {
+        newsArticleService.deletePhysically(articleId);
         return ResponseEntity.noContent().build();
     }
 
     private static final Set<String> VALID_ORDER_BY = Set.of("publishDate", "commentCount", "viewCount");
     private static final Set<String> VALID_DIRECTION = Set.of("ASC", "DESC");
-
 
     private void validateOrderBy(String orderBy) {
         if (!VALID_ORDER_BY.contains(orderBy)) {
@@ -93,5 +97,4 @@ public class NewsArticleController {
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, detail, ExceptionType.NEWSARTICLE);
         }
     }
-
 }

--- a/src/main/java/com/team03/monew/controller/NewsArticleController.java
+++ b/src/main/java/com/team03/monew/controller/NewsArticleController.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -66,6 +67,13 @@ public class NewsArticleController {
     @GetMapping("/sources")
     public ResponseEntity<SourcesResponseDto> getSources() {
         return ResponseEntity.ok(newsArticleService.getSources());
+    }
+
+    @DeleteMapping("/{articleId}")
+    public ResponseEntity<Void> deleteArticleLogical(@PathVariable UUID articleId) {
+        newsArticleService.deleteLogically(articleId);
+
+        return ResponseEntity.noContent().build();
     }
 
     private static final Set<String> VALID_ORDER_BY = Set.of("publishDate", "commentCount", "viewCount");

--- a/src/main/java/com/team03/monew/entity/NewsArticle.java
+++ b/src/main/java/com/team03/monew/entity/NewsArticle.java
@@ -65,5 +65,9 @@ public class NewsArticle {
     this.viewCount++;
   }
 
+  // 논리 삭제
+  public void markAsDeleted() {
+    this.deleted = true;
+  }
   // getter/setter
 }

--- a/src/main/java/com/team03/monew/service/NewsArticleService.java
+++ b/src/main/java/com/team03/monew/service/NewsArticleService.java
@@ -92,6 +92,17 @@ public class NewsArticleService {
         return new SourcesResponseDto(sources);
     }
 
+    @Transactional
+    public void deleteLogically(UUID articleId) {
+        NewsArticle article = newsArticleRepository.findByIdAndDeletedFalse(articleId)
+            .orElseThrow(() ->{
+                ErrorDetail detail = new ErrorDetail("UUID", "articleId", articleId.toString());
+                return new CustomException(ErrorCode.RESOURCE_NOT_FOUND, detail, ExceptionType.NEWSARTICLE);
+            });
+
+        article.markAsDeleted(); // 엔티티에서 delete를 true로 변경
+    }
+
     // 마지막 요소의 커서 인코딩
     public String encodeCursor(ArticleDto lastArticle) {
         // publishDate 기준

--- a/src/main/java/com/team03/monew/service/NewsArticleService.java
+++ b/src/main/java/com/team03/monew/service/NewsArticleService.java
@@ -103,6 +103,17 @@ public class NewsArticleService {
         article.markAsDeleted(); // 엔티티에서 delete를 true로 변경
     }
 
+    @Transactional
+    public void deletePhysically(UUID articleId) {
+        NewsArticle article = newsArticleRepository.findById(articleId)
+            .orElseThrow(() -> {
+                ErrorDetail detail = new ErrorDetail("UUID", "articleId", articleId.toString());
+                return new CustomException(ErrorCode.RESOURCE_NOT_FOUND, detail, ExceptionType.NEWSARTICLE);
+            });
+
+        newsArticleRepository.delete(article);
+    }
+
     // 마지막 요소의 커서 인코딩
     public String encodeCursor(ArticleDto lastArticle) {
         // publishDate 기준

--- a/src/test/java/com/team03/monew/controller/NewsArticleControllerTest.java
+++ b/src/test/java/com/team03/monew/controller/NewsArticleControllerTest.java
@@ -93,7 +93,6 @@ class NewsArticleControllerTest {
             .andExpect(status().isNotFound());
     }
 
-
     @Test
     @DisplayName("뉴스 기사 목록 조회 성공")
     void getArticles_Success() throws Exception {
@@ -168,8 +167,6 @@ class NewsArticleControllerTest {
             ExceptionType.NEWSARTICLE
         )).given(newsArticleService).deleteLogically(articleId);
 
-
-
         mockMvc.perform(delete("/api/articles/{id}", articleId))
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"))
@@ -178,9 +175,35 @@ class NewsArticleControllerTest {
             .andExpect(jsonPath("$.details.value").value(articleId.toString()));
     }
 
+    @DisplayName("뉴스 기사 물리 삭제 성공")
+    @Test
+    void deleteArticlePhysically_Success() throws Exception {
+        UUID articleId = UUID.randomUUID();
 
+        willDoNothing().given(newsArticleService).deletePhysically(articleId);
 
+        mockMvc.perform(delete("/api/articles/{id}/hard", articleId))
+            .andExpect(status().isNoContent());
+    }
 
+    @DisplayName("뉴스 기사 물리 삭제 실패 - 존재하지 않는 기사")
+    @Test
+    void deleteArticlePhysically_Fail_NotFound() throws Exception {
+        UUID articleId = UUID.randomUUID();
+
+        willThrow(new CustomException(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            new ErrorDetail("UUID", "articleId", articleId.toString()),
+            ExceptionType.NEWSARTICLE
+        )).given(newsArticleService).deletePhysically(articleId);
+
+        mockMvc.perform(delete("/api/articles/{id}/hard", articleId))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"))
+            .andExpect(jsonPath("$.exceptionType").value("NEWSARTICLE"))
+            .andExpect(jsonPath("$.details.parameter").value("articleId"))
+            .andExpect(jsonPath("$.details.value").value(articleId.toString()));
+    }
 
     public static ArticleDto createMockArticle() {
         return new ArticleDto(


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #42

---

## 📌 작업 개요
뉴스 기사 데이터를 사용자에게 보이지 않도록 처리하는 논리 삭제 기능과,  
DB에서 완전히 제거하는 물리 삭제 기능을 각각 구현했습니다.

---

## 🛠 작업 상세 내용
### 논리 삭제
- `DELETE /api/articles/{id}`
- `deleted` 플래그를 `true`로 설정
- 실제 DB 삭제는 아님
- 조회 API 등에서는 `deleted = false` 조건으로 제외 처리
- 예외: 존재하지 않거나 이미 삭제된 경우 404

### 물리 삭제
- `DELETE /api/articles/{id}/hard`
- DB에서 직접 `delete()` 호출하여 데이터 완전 제거
- 논리 삭제 여부와 관계없이 삭제 가능
- 예외: 존재하지 않는 기사일 경우 404
