### PR TITLE
Feature/48 뉴스 복구 API 구현 (Local 환경 기반 임시 구현) + ArticleView 연관관계 리팩토링

### DIFF
--- a/src/main/java/com/team03/monew/controller/NewsArticleController.java
+++ b/src/main/java/com/team03/monew/controller/NewsArticleController.java
@@ -1,5 +1,6 @@
 package com.team03.monew.controller;
 
+import com.team03.monew.dto.newsArticle.response.ArticleRestoreResultDto;
 import com.team03.monew.dto.newsArticle.response.ArticleViewDto;
 import com.team03.monew.dto.newsArticle.response.CursorPageResponseArticleDto;
 import com.team03.monew.dto.newsArticle.response.SourcesResponseDto;
@@ -8,6 +9,7 @@ import com.team03.monew.exception.ErrorCode;
 import com.team03.monew.exception.ErrorDetail;
 import com.team03.monew.exception.ExceptionType;
 import com.team03.monew.service.NewsArticleService;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
@@ -79,6 +81,15 @@ public class NewsArticleController {
     public ResponseEntity<Void> deleteArticleHard(@PathVariable UUID articleId) {
         newsArticleService.deletePhysically(articleId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/restore")
+    public ResponseEntity<List<ArticleRestoreResultDto>> restoreArticles(
+        @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+        @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+
+        List<ArticleRestoreResultDto> results = newsArticleService.restore(from, to);
+        return ResponseEntity.ok(results);
     }
 
     private static final Set<String> VALID_ORDER_BY = Set.of("publishDate", "commentCount", "viewCount");

--- a/src/main/java/com/team03/monew/dto/newsArticle/mapper/ArticleViewMapper.java
+++ b/src/main/java/com/team03/monew/dto/newsArticle/mapper/ArticleViewMapper.java
@@ -10,7 +10,7 @@ public class ArticleViewMapper {
         NewsArticle a = view.getArticle();
         return new ArticleViewDto(
             view.getId(),
-            view.getUserId(),
+            view.getUser().getId(),
             view.getCreatedAt(),
             a.getId(),
             a.getSource(),

--- a/src/main/java/com/team03/monew/dto/newsArticle/response/ArticleRestoreResultDto.java
+++ b/src/main/java/com/team03/monew/dto/newsArticle/response/ArticleRestoreResultDto.java
@@ -1,10 +1,11 @@
-package com.team03.monew.dto.newsArticle;
+package com.team03.monew.dto.newsArticle.response;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 public record ArticleRestoreResultDto(
     LocalDateTime restoreDate,
-    List<String> restoredArticleIds,
+    List<UUID> restoredArticleIds,
     int restoredArticleCount
 ) {}

--- a/src/main/java/com/team03/monew/dto/newsArticle/response/NewsBackupDto.java
+++ b/src/main/java/com/team03/monew/dto/newsArticle/response/NewsBackupDto.java
@@ -1,0 +1,15 @@
+package com.team03.monew.dto.newsArticle.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+// 백업된 json 파일을 읽어서 매핑하기 위한 dto
+public record NewsBackupDto (
+    UUID id,
+    String source,
+    String originalLink,
+    String title,
+    LocalDateTime date,
+    String summary,
+    UUID interestId
+) {}

--- a/src/main/java/com/team03/monew/entity/ArticleView.java
+++ b/src/main/java/com/team03/monew/entity/ArticleView.java
@@ -31,15 +31,16 @@ public class ArticleView {
     @JoinColumn(name = "article_id", nullable = false)
     private NewsArticle article;
 
-    @Column(nullable = false)
-    private UUID userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @Column(nullable = false)
     private LocalDateTime createdAt = LocalDateTime.now();
 
-    public ArticleView(NewsArticle article, UUID userId) {
+    public ArticleView(NewsArticle article, User user) {
         this.article = article;
-        this.userId = userId;
+        this.user = user;
     }
 }
 

--- a/src/main/java/com/team03/monew/entity/NewsArticle.java
+++ b/src/main/java/com/team03/monew/entity/NewsArticle.java
@@ -52,9 +52,6 @@ public class NewsArticle {
   @OneToMany(mappedBy = "news", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Comment> comments = new ArrayList<>();
 
-  @OneToMany(mappedBy = "article", cascade = CascadeType.REMOVE, orphanRemoval = true)
-  private List<ArticleView> articleViews = new ArrayList<>();
-
   // 연관관계 편의 메서드
   public void addComment(Comment comment) {
     comments.add(comment);

--- a/src/main/java/com/team03/monew/entity/NewsArticle.java
+++ b/src/main/java/com/team03/monew/entity/NewsArticle.java
@@ -15,9 +15,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@NoArgsConstructor
 @Table(name = "news_articles")
 public class NewsArticle {
   @Id @GeneratedValue
@@ -50,6 +52,9 @@ public class NewsArticle {
   @OneToMany(mappedBy = "news", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Comment> comments = new ArrayList<>();
 
+  @OneToMany(mappedBy = "article", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  private List<ArticleView> articleViews = new ArrayList<>();
+
   // 연관관계 편의 메서드
   public void addComment(Comment comment) {
     comments.add(comment);
@@ -69,5 +74,19 @@ public class NewsArticle {
   public void markAsDeleted() {
     this.deleted = true;
   }
+
+  // 복구 시 사용할 생성자
+  public NewsArticle(String source, String originalLink, String title,
+      LocalDateTime date, String summary, Interest interest) {
+    this.source = source;
+    this.originalLink = originalLink;
+    this.title = title;
+    this.date = date;
+    this.summary = summary;
+    this.interest = interest;
+    this.viewCount = 0;
+    this.deleted = false;
+  }
+
   // getter/setter
 }

--- a/src/main/java/com/team03/monew/repository/ArticleViewRepository.java
+++ b/src/main/java/com/team03/monew/repository/ArticleViewRepository.java
@@ -1,10 +1,14 @@
 package com.team03.monew.repository;
 
 import com.team03.monew.entity.ArticleView;
+import com.team03.monew.entity.NewsArticle;
+import com.team03.monew.entity.User;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID> {
-    Optional<ArticleView> findByArticleIdAndUserId(UUID articleId, UUID userId);
+    Optional<ArticleView> findByArticleAndUser(NewsArticle article, User user);
+
+    void deleteByArticle(NewsArticle article);
 }

--- a/src/main/java/com/team03/monew/repository/NewsArticleRepository.java
+++ b/src/main/java/com/team03/monew/repository/NewsArticleRepository.java
@@ -16,4 +16,7 @@ public interface NewsArticleRepository extends JpaRepository<NewsArticle, UUID>,
     // 출처 목록 조회용
     @Query("SELECT DISTINCT n.source FROM NewsArticle n WHERE n.deleted = false")
     List<String> findDistinctSources();
+
+    // 복구용. 이미 데이터베이스에 존재하는지 확인
+    boolean existsByOriginalLink(String originalLink);
 }

--- a/src/main/java/com/team03/monew/service/NewsArticleService.java
+++ b/src/main/java/com/team03/monew/service/NewsArticleService.java
@@ -133,6 +133,7 @@ public class NewsArticleService {
                 return new CustomException(ErrorCode.RESOURCE_NOT_FOUND, detail, ExceptionType.NEWSARTICLE);
             });
 
+        articleViewRepository.deleteByArticle(article);
         newsArticleRepository.delete(article);
     }
 

--- a/src/main/java/com/team03/monew/storage/BackupStorage.java
+++ b/src/main/java/com/team03/monew/storage/BackupStorage.java
@@ -1,0 +1,9 @@
+package com.team03.monew.storage;
+
+import com.team03.monew.dto.newsArticle.response.NewsBackupDto;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface BackupStorage {
+    List<NewsBackupDto> loadBackup(LocalDate date);
+}

--- a/src/main/java/com/team03/monew/storage/LocalBackupStorage.java
+++ b/src/main/java/com/team03/monew/storage/LocalBackupStorage.java
@@ -1,0 +1,37 @@
+package com.team03.monew.storage;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.team03.monew.dto.newsArticle.response.NewsBackupDto;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+// aws 설정이 진행되지 않아 우선 로컬로 구현
+@Component
+//@Profile("local")
+public class LocalBackupStorage implements BackupStorage {
+
+    @Override
+    public List<NewsBackupDto> loadBackup(LocalDate date) {
+        String filename = "mock-backup/news-" + date + ".json";
+
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream(filename)) {
+            if (is == null) {
+                throw new RuntimeException("백업 파일이 classpath에서 발견되지 않음: " + filename);
+            }
+
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.registerModule(new JavaTimeModule()); // LocalDateTime 대응
+            mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+            return mapper.readValue(is, new TypeReference<>() {});
+        } catch (IOException e) {
+            throw new RuntimeException("백업 파일 로딩 실패: " + filename, e);
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #48

---

## 📌 작업 개요
- 외부에서 뉴스 정보를 가져와 저장하는 작업에서 누락된 뉴스를 복구하는 기능 구현(현재는 S3 설정이 진행되지 않아 로컬 기준으로 작성했습니다.)
- 조회수 기록을 위한 ArticleView 연관관계 리팩토링(사용자, 뉴스 기사 삭제 시 제거되도록)

---

## 🛠 작업 상세 내용
[뉴스 복구 API]
- `/api/articles/restore` GET API 구현
- `from`, `to` 날짜를 기준으로 백업 파일을 순회하며 복구 작업 수행
- 현재는 AWS S3 설정이 완료되지 않아, `src/main/resources/mock-backup` 내 JSON 파일을 읽는 방식으로 구현
- 기존 `originalLink` 기준으로 중복 여부를 검사하여, 존재하지 않는 기사만 복구
- 복구 결과는 `restoreDate`, `restoredArticleIds`, `restoredArticleCount`로 구성된 DTO로 응답

[ArticleView]
- User → ArticleView 연관관계에 `cascade = REMOVE`, `orphanRemoval = true` 설정
  → User 삭제 시 관련 ArticleView 자동 삭제
ArticleView와 관련된 파일 변화는 단순 연관관계 설정 및 관련된 필드 변경입니다.

### ✅ 추후 작업 예정
[뉴스 복구 API]
- AWS S3 설정 후 `S3BackupStorage` 구현체 추가 예정
- 배치 작업 시 자동 백업 및 복구 자동화 예정
[ArticleView]
- 현재는 User 쪽에서만 생명주기를 관리하는 구조이나,  
  추후 뉴스 기사 중심의 통계/분석 기능이 추가될 경우  
  → NewsArticle → ArticleView 방향으로의 책임 이전도 고려할 수 있음
