### PR TITLE
Feature/16 사용자 삭제 기능 구현(논리 삭제, 물리삭제 적용)

### DIFF
--- a/src/main/java/com/team03/monew/controller/UserController.java
+++ b/src/main/java/com/team03/monew/controller/UserController.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,7 +30,7 @@ public class UserController {
         return ResponseEntity.status(201).body(userDto);
     }
 
-    @PatchMapping
+    @PatchMapping("/{userId}")
     public ResponseEntity<UserDto> updateNickname(
         @PathVariable UUID userId,
         @RequestBody @Valid UserUpdateRequest request,
@@ -37,5 +38,23 @@ public class UserController {
     ) {
         UserDto updated = userService.updateNickname(userId, requesterId, request);
         return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<Void> deleteUser(
+        @PathVariable UUID userId,
+        @RequestHeader("MoNew-Request-User-ID") UUID requesterId
+    ) {
+        userService.deleteUser(userId, requesterId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{userId}/hard")
+    public ResponseEntity<Void> deleteUserHard(
+        @PathVariable UUID userId,
+        @RequestHeader("MoNew-Request-User-ID") UUID requesterId
+    ) {
+        userService.deleteUserHard(userId, requesterId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/team03/monew/entity/Activity.java
+++ b/src/main/java/com/team03/monew/entity/Activity.java
@@ -15,24 +15,25 @@ import java.util.UUID;
 @Entity
 @Table(name = "activities")
 public class Activity {
-  @Id
-  private UUID userId;
 
-  @ElementCollection
-  private List<Long> recentCommentIds = new ArrayList<>();
+    @Id
+    private UUID userId;
 
-  @ElementCollection
-  private List<Long> recentLikedCommentIds = new ArrayList<>();
+    @ElementCollection
+    private List<Long> recentCommentIds = new ArrayList<>();
 
-  @ElementCollection
-  private List<Long> recentViewedNewsIds = new ArrayList<>();
+    @ElementCollection
+    private List<Long> recentLikedCommentIds = new ArrayList<>();
 
-  @ElementCollection
-  private List<Long> subscribedInterestIds = new ArrayList<>();
+    @ElementCollection
+    private List<Long> recentViewedNewsIds = new ArrayList<>();
 
-  @OneToOne(fetch = FetchType.LAZY)
-  @MapsId
-  private User user;
+    @ElementCollection
+    private List<Long> subscribedInterestIds = new ArrayList<>();
 
-  // getter/setter
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId // user 필드에서 참조하는 User의 ID를 이 엔티티의 PK로 사용
+    private User user;
+
+    // getter/setter
 }

--- a/src/main/java/com/team03/monew/entity/User.java
+++ b/src/main/java/com/team03/monew/entity/User.java
@@ -1,17 +1,23 @@
 package com.team03.monew.entity;
 
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "users")
+@Where(clause = "deleted = false")
 @Getter
 @NoArgsConstructor
 public class User extends BaseTimeEntity {
@@ -32,6 +38,21 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private boolean deleted = false;
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<ArticleView> articleViews = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Subscription> subscriptions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<CommentLike> commentLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Notification> notifications = new ArrayList<>();
+
     public User(String email, String nickname, String password) {
         this.email = email;
         this.nickname = nickname;
@@ -41,5 +62,10 @@ public class User extends BaseTimeEntity {
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    // 사용자 계정을 논리적으로 삭제 (true 값으로 전환)
+    public void markAsDeleted() {
+        this.deleted = true;
     }
 }

--- a/src/main/java/com/team03/monew/repository/ActivityRepository.java
+++ b/src/main/java/com/team03/monew/repository/ActivityRepository.java
@@ -1,9 +1,11 @@
 package com.team03.monew.repository;
 
 import com.team03.monew.entity.Activity;
+import com.team03.monew.entity.User;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ActivityRepository extends JpaRepository<Activity, UUID> {
 
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/team03/monew/repository/UserRepository.java
+++ b/src/main/java/com/team03/monew/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByEmail(String email);
 
     boolean existsByEmail(String email);
+
+    Optional<User> findByIdAndDeletedFalse(UUID id);
 }

--- a/src/main/java/com/team03/monew/service/UserService.java
+++ b/src/main/java/com/team03/monew/service/UserService.java
@@ -10,4 +10,8 @@ public interface UserService {
     UserDto register(UserRegisterRequest request);
 
     UserDto updateNickname(UUID userId, UUID requesterId, UserUpdateRequest request);
+
+    void deleteUser(UUID userId, UUID requesterId);
+
+    void deleteUserHard(UUID userId, UUID requesterId);
 }


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #16 

---

## 📌 작업 개요
<!-- 어떤 작업을 했는지 간단하게 요약해주세요 -->
- 사용자 삭제 기능 구현
- 논리 삭제 및 물리 삭제 API 분리 처리

---

## 🛠 작업 상세 내용
<!-- 주요 작업 내용을 리스트로 정리해주세요 -->
- `DELETE /api/users/{userId}` 논리 삭제 API 구현
- `User.deleted` 필드를 true로 설정하는 서비스 로직 추가
-  요청자 ID(`MoNew-Request-User-ID`)를 통해 본인만 삭제 가능하도록 권한 체크
- `DELETE /api/users/{userId}/hard` 물리 삭제 API 추가 구현
- `@OneToMany + cascade = REMOVE`를 통해 사용자 연관 정보 자동 삭제 처리
- `Activity`는 1:1 관계(`@MapsId`)로 연결되어 있어 수동 삭제 처리 적용
- 사용자 존재하지 않음(404) 및 권한 없음(403) 상황에 대한 예외 처리 추가
