### PR TITLE
Feature/17 사용자 로그인 구현

### DIFF
--- a/src/main/java/com/team03/monew/controller/UserController.java
+++ b/src/main/java/com/team03/monew/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.team03.monew.controller;
 
 import com.team03.monew.dto.user.UserDto;
+import com.team03.monew.dto.user.UserLoginRequest;
 import com.team03.monew.dto.user.UserRegisterRequest;
 import com.team03.monew.dto.user.UserUpdateRequest;
 import com.team03.monew.service.UserService;
@@ -57,4 +58,11 @@ public class UserController {
         userService.deleteUserHard(userId, requesterId);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/login")
+    public ResponseEntity<UserDto> login(@RequestBody @Valid UserLoginRequest request) {
+        UserDto userDto = userService.login(request);
+        return ResponseEntity.ok(userDto);
+    }
+
 }

--- a/src/main/java/com/team03/monew/dto/user/UserLoginRequest.java
+++ b/src/main/java/com/team03/monew/dto/user/UserLoginRequest.java
@@ -1,0 +1,16 @@
+package com.team03.monew.dto.user;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserLoginRequest(
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "유효한 이메일 형식이여야 합니다.")
+    String email,
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    String password
+) {
+
+}

--- a/src/main/java/com/team03/monew/dto/user/mapper/UserMapper.java
+++ b/src/main/java/com/team03/monew/dto/user/mapper/UserMapper.java
@@ -1,5 +1,7 @@
-package com.team03.monew.dto.user;
+package com.team03.monew.dto.user.mapper;
 
+import com.team03.monew.dto.user.UserDto;
+import com.team03.monew.dto.user.UserRegisterRequest;
 import com.team03.monew.entity.User;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/team03/monew/service/UserService.java
+++ b/src/main/java/com/team03/monew/service/UserService.java
@@ -1,6 +1,7 @@
 package com.team03.monew.service;
 
 import com.team03.monew.dto.user.UserDto;
+import com.team03.monew.dto.user.UserLoginRequest;
 import com.team03.monew.dto.user.UserRegisterRequest;
 import com.team03.monew.dto.user.UserUpdateRequest;
 import java.util.UUID;
@@ -14,4 +15,6 @@ public interface UserService {
     void deleteUser(UUID userId, UUID requesterId);
 
     void deleteUserHard(UUID userId, UUID requesterId);
+
+    UserDto login(UserLoginRequest request);
 }

--- a/src/main/java/com/team03/monew/service/UserServiceImpl.java
+++ b/src/main/java/com/team03/monew/service/UserServiceImpl.java
@@ -1,7 +1,8 @@
 package com.team03.monew.service;
 
 import com.team03.monew.dto.user.UserDto;
-import com.team03.monew.dto.user.UserMapper;
+import com.team03.monew.dto.user.UserLoginRequest;
+import com.team03.monew.dto.user.mapper.UserMapper;
 import com.team03.monew.dto.user.UserRegisterRequest;
 import com.team03.monew.dto.user.UserUpdateRequest;
 import com.team03.monew.entity.User;
@@ -87,6 +88,21 @@ public class UserServiceImpl implements UserService {
 
         // 사용자 계정을 물리적으로 삭제 처리 (연관 요소 cascade 로 자동 삭제)
         userRepository.delete(user);
+    }
+
+    @Override
+    public UserDto login(UserLoginRequest request) {
+        User user = userRepository.findByEmail(request.email()).orElseThrow(() -> {
+            ErrorDetail detail = new ErrorDetail("EMAIL", "email", request.email());
+            return new CustomException(ErrorCode.RESOURCE_NOT_FOUND, detail, ExceptionType.USER);
+        });
+
+        if (!user.getPassword().equals(request.password())) {
+            ErrorDetail detail = new ErrorDetail("PASSWORD", "password", request.password());
+            throw new CustomException(ErrorCode.UNAUTHORIZED, detail, ExceptionType.USER);
+        }
+
+        return userMapper.toDto(user);
     }
 
 }


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #17

---

## 📌 작업 개요
<!-- 어떤 작업을 했는지 간단하게 요약해주세요 -->
- 사용자 로그인 기능 구현
- 이메일/비밀번호 기반 로그인 요청 처리 및 사용자 정보 반환

---

## 🛠 작업 상세 내용
<!-- 주요 작업 내용을 리스트로 정리해주세요 -->
- `UserLoginRequest` DTO 설계 (`email`, `password` 포함)
- 로그인 API 추가: `POST /api/users/login`
- `UserService.login()` 메서드 구현
  - 이메일 존재 여부 확인
  - 비밀번호 일치 여부 검증
- 로그인 실패 시 예외 처리
  - 이메일 없음 → `404 Not Found`
  - 비밀번호 불일치 → `401 Unauthorized`
- 로그인 성공 시 `UserDto` 반환 (id, email, nickname, createdAt 포함)
- 예외 응답은 기존 `ErrorResponse` 포맷 따름