### PR TITLE
Fix/70 뉴스 기사 수집 및 저장 로직 개선

### DIFF
--- a/src/main/java/com/team03/monew/dto/newsArticle/request/NewsArticleRequestDto.java
+++ b/src/main/java/com/team03/monew/dto/newsArticle/request/NewsArticleRequestDto.java
@@ -1,24 +1,14 @@
 package com.team03.monew.dto.newsArticle.request;
 
-import com.team03.monew.entity.NewsArticle;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public record NewsArticleRequestDto(
     String title,
     String originalLink,
     String summary,
     LocalDateTime date,
-    String source
-) {
-    public NewsArticle toEntity() {
-        return NewsArticle.builder()
-            .title(title)
-            .originalLink(originalLink)
-            .summary(summary)
-            .date(date)
-            .source(source)
-            .deleted(false)
-            .viewCount(0)
-            .build();
-    }
-}
+    String source,
+    UUID interestId
+) {}
+

--- a/src/main/java/com/team03/monew/entity/NewsArticle.java
+++ b/src/main/java/com/team03/monew/entity/NewsArticle.java
@@ -28,7 +28,7 @@ public class NewsArticle {
   @Column(nullable = false)
   private String source;
 
-  @Column(nullable = false, unique = true)
+  @Column(columnDefinition = "text", nullable = false, unique = true)
   private String originalLink;
 
   @Column(nullable = false)
@@ -73,9 +73,10 @@ public class NewsArticle {
   }
 
   @Builder
-  public NewsArticle(String source, String originalLink, String title,
+  public NewsArticle(UUID id, String source, String originalLink, String title,
       LocalDateTime date, String summary,
       Interest interest, int viewCount, boolean deleted) {
+    this.id = id;
     this.source = source;
     this.originalLink = originalLink;
     this.title = title;

--- a/src/main/java/com/team03/monew/external/naver/NaverApiCollector.java
+++ b/src/main/java/com/team03/monew/external/naver/NaverApiCollector.java
@@ -1,5 +1,7 @@
 package com.team03.monew.external.naver;
 
+import com.team03.monew.dto.newsArticle.request.NewsArticleRequestDto;
+import com.team03.monew.entity.Interest;
 import com.team03.monew.repository.InterestRepository;
 import com.team03.monew.service.NewsArticleService;
 import java.net.URLEncoder;
@@ -27,32 +29,37 @@ public class NaverApiCollector {
     private final InterestRepository interestRepository;
 
     public void collect() {
-        List<String> keywords = interestRepository.findAllKeywords();
+        List<Interest> interests = interestRepository.findAll();
 
-        for (String keyword : keywords) {
-            try {
-                // 키워드를 인코딩하여 api 호출
-                String encoded = URLEncoder.encode(keyword, StandardCharsets.UTF_8);
-                String url = "https://openapi.naver.com/v1/search/news.json?query=" + encoded + "&display=10&sort=date";
+        for (Interest interest : interests) {
+            for (String keyword : interest.getKeywords()) {
+                try {
+                    // 키워드를 인코딩하여 api 호출
+                    String encoded = URLEncoder.encode(keyword, StandardCharsets.UTF_8);
+                    String url = "https://openapi.naver.com/v1/search/news.json?query=" + encoded + "&display=10&sort=date";
 
-                // 인증 헤더 추가
-                HttpHeaders headers = new HttpHeaders();
-                headers.set("X-Naver-Client-Id", clientId);
-                headers.set("X-Naver-Client-Secret", clientSecret);
+                    // 인증 헤더 추가
+                    HttpHeaders headers = new HttpHeaders();
+                    headers.set("X-Naver-Client-Id", clientId);
+                    headers.set("X-Naver-Client-Secret", clientSecret);
 
-                // api 호출 및 응답 매핑
-                HttpEntity<Void> request = new HttpEntity<>(headers);
-                ResponseEntity<NaverResponseDto> response = new RestTemplate().exchange(
-                    url, HttpMethod.GET, request, NaverResponseDto.class);
+                    // api 호출 및 응답 매핑
+                    HttpEntity<Void> request = new HttpEntity<>(headers);
+                    ResponseEntity<NaverResponseDto> response = new RestTemplate().exchange(
+                        url, HttpMethod.GET, request, NaverResponseDto.class);
 
-                // 응답에서 각 기사 리스트 추출
-                List<NaverNewsItem> items = response.getBody().getItems();
-                for (NaverNewsItem item : items) {
-                    newsArticleService.saveIfNotExists(item.toDto());
+                    // 응답에서 각 기사 리스트 추출
+                    List<NaverNewsItem> items = response.getBody().getItems();
+                    for (NaverNewsItem item : items) {
+                        // DTO로 변환
+                        NewsArticleRequestDto dto = item.toDto(interest.getId());
+                        newsArticleService.saveIfNotExists(dto);
+                    }
+
+                } catch (Exception e) {
+                    System.err.println("네이버 뉴스 수집 실패: " + keyword);
+                    e.printStackTrace();
                 }
-            } catch (Exception e) {
-                System.err.println("네이버 뉴스 수집 실패: " + keyword);
-                e.printStackTrace();
             }
         }
     }

--- a/src/main/java/com/team03/monew/external/naver/NaverNewsItem.java
+++ b/src/main/java/com/team03/monew/external/naver/NaverNewsItem.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.UUID;
 import lombok.Data;
 import org.jsoup.Jsoup;
 
@@ -17,13 +18,14 @@ public class NaverNewsItem {
     private String description;
     private String pubDate;
 
-    public NewsArticleRequestDto toDto() {
+    public NewsArticleRequestDto toDto(UUID interestId) {
         return new NewsArticleRequestDto(
-            removeTags(title),
-            originallink,
-            cleanSummary(description),
-            parse(pubDate),
-            "네이버뉴스"
+            this.title,
+            this.link,
+            cleanSummary(this.description),
+            parse(this.pubDate),
+            "NAVER",
+            interestId
         );
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #70

---

## 📌 작업 개요
- originalLink(뉴스 원문 링크) 필드 길이 초과 오류 수정
- 관심사 정보 누락 문제 수정

---

## 🛠 작업 상세 내용
1. originalLink 필드 길이 초과 오류 수정(NewsArticle.java)
- 일부 뉴스의 본문 링크가 255자를 초과해 저장 실패 발생
- JPA에서 columnDefinition = "text"로 지정

2. 관심사 정보 누락 문제 해결
- 기존에는 키워드가 포함된 뉴스만 저장되었으나, 어떤 관심사인지 저장되지 않음
- 제목/요약에 포함된 키워드를 기반으로 Interest를 식별하고, 해당 ID를 DTO에 포함하여 저장 시 연관관계 설정

3. 수집기 로직 개선
- RSS 수집기: 뉴스 제목/요약을 기준으로 관심사 매칭 후 interestId 주입
- Naver API 수집기: 각 Interest 키워드로 검색하여 해당 interestId를 주입

---

## 참고사항
- DTO는 UUID만 포함하고, 서비스에서 Interest를 주입함으로써 책임을 분리했습니다.
- 키워드 매칭은 contains 기반으로 작성했습니다.
- 현재는 하나의 뉴스 기사에 하나의 관심사만 적용되어 있는데 
  여러 개의 관심사가 적용되려면 NewsArticle <-> Interest 다대다 양방향 구조 확장이 필요할 수 있습니다.