### PR TITLE
댓글, 관심사 관련 알림 발생

### DIFF
--- a/src/main/java/com/team03/monew/controller/CommentController.java
+++ b/src/main/java/com/team03/monew/controller/CommentController.java
@@ -5,6 +5,7 @@ import com.team03.monew.dto.comment.response.CommentLikeDto;
 import com.team03.monew.dto.comment.request.CommentRegisterRequest;
 import com.team03.monew.dto.comment.response.CommentDto;
 import com.team03.monew.dto.comment.response.CursorPageResponseCommentDto;
+import com.team03.monew.service.NotificationService;
 import com.team03.monew.util.OrderBy;
 import com.team03.monew.util.SortDirection;
 import com.team03.monew.service.CommentService;
@@ -34,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentController {
 
     private final CommentService commentService;
+    private final NotificationService notificationService;
 
     @GetMapping()
     public CursorPageResponseCommentDto<CommentDto> getCommentsWithCursorPaging(
@@ -60,6 +62,8 @@ public class CommentController {
     @PostMapping("/{commentId}/comment-likes")
     public ResponseEntity<CommentLikeDto> addCommentLike(@PathVariable UUID commentId,  @RequestHeader("Monew-Request-User-ID") UUID userId) {
         CommentLikeDto commentLikeDto = commentService.commentLikes(commentId, userId);
+        notificationService.notifyCommentLiked(userId,commentId);
+
         return ResponseEntity.status(HttpStatus.OK).body(commentLikeDto);
     }
 

--- a/src/main/java/com/team03/monew/controller/InterestController.java
+++ b/src/main/java/com/team03/monew/controller/InterestController.java
@@ -6,6 +6,7 @@ import com.team03.monew.dto.interest.InterestRegisterRequest;
 import com.team03.monew.dto.interest.InterestUpdateRequest;
 import com.team03.monew.dto.subscription.SubscriptionDto;
 import com.team03.monew.service.InterestService;
+import com.team03.monew.service.NotificationService;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class InterestController {
 
   private final InterestService interestService;
+  private final NotificationService notificationService;
 
   @PostMapping
   public ResponseEntity<InterestDto> registerInterest(@RequestBody @Valid InterestRegisterRequest request) {
@@ -69,6 +71,7 @@ public class InterestController {
       @RequestHeader("Monew-Request-User-ID") UUID userId
   ) {
     SubscriptionDto dto = interestService.subscribe(interestId, userId);
+
     return ResponseEntity.ok(dto);
   }
 

--- a/src/main/java/com/team03/monew/entity/Notification.java
+++ b/src/main/java/com/team03/monew/entity/Notification.java
@@ -11,11 +11,17 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
 @Table(name = "notifications")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 @Setter
 public class Notification {

--- a/src/main/java/com/team03/monew/repository/SubscriptionRepository.java
+++ b/src/main/java/com/team03/monew/repository/SubscriptionRepository.java
@@ -1,12 +1,19 @@
 package com.team03.monew.repository;
 
+import com.team03.monew.entity.Interest;
 import com.team03.monew.entity.Subscription;
+import com.team03.monew.entity.User;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
   Optional<Subscription> findByUserIdAndInterestId(UUID userId, UUID interestId);
   void deleteByUserIdAndInterestId(UUID userId, UUID interestId);
   boolean existsByUserIdAndInterestId(UUID userId, UUID interestId);
+  @Query("SELECT s.user FROM Subscription s WHERE s.interest = :interest")
+  List<User> findAllByInterest(@Param("interest") Interest interest);
 }

--- a/src/main/java/com/team03/monew/scheduler/NewsScheduler.java
+++ b/src/main/java/com/team03/monew/scheduler/NewsScheduler.java
@@ -17,6 +17,7 @@ public class NewsScheduler {
     @Scheduled(cron = "0 0 * * * *") // 매 시 정각마다 실행
     public void collectNews() {
         System.out.println("[Scheduler] 수집 시작됨");
+
         naverApiCollector.collect();
         rssCollector.collectAll();
     }

--- a/src/main/java/com/team03/monew/service/InterestService.java
+++ b/src/main/java/com/team03/monew/service/InterestService.java
@@ -17,9 +17,12 @@ import com.team03.monew.repository.SubscriptionRepository;
 import com.team03.monew.repository.UserRepository;
 import com.team03.monew.util.SimilarityUtil;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -132,6 +135,18 @@ public class InterestService {
             "interest","interesdId","interest"
         ), ExceptionType.INTEREST));
     interestRepository.delete(interest);
+  }
+
+  public Map<Interest, List<String>> getInterestKeywordMap() {
+    List<Interest> interests = interestRepository.findAll();
+
+    Map<Interest, List<String>> result = new HashMap<>();
+    for (Interest interest : interests) {
+      List<String> keywordNames = interest.getKeywords();
+      result.put(interest, keywordNames);
+    }
+
+    return result;
   }
 
   private void increaseSubscriberCount(Interest interest) {

--- a/src/main/java/com/team03/monew/service/NotificationService.java
+++ b/src/main/java/com/team03/monew/service/NotificationService.java
@@ -2,13 +2,23 @@ package com.team03.monew.service;
 
 import com.team03.monew.dto.notification.CursorPageResponseNotificationDto;
 import com.team03.monew.dto.notification.NotificationDto;
+import com.team03.monew.entity.Interest;
 import com.team03.monew.entity.Notification;
+import com.team03.monew.entity.User;
+import com.team03.monew.exception.CustomException;
+import com.team03.monew.exception.ErrorCode;
+import com.team03.monew.exception.ErrorDetail;
+import com.team03.monew.exception.ExceptionType;
+import com.team03.monew.repository.InterestRepository;
 import com.team03.monew.repository.NotificationRepository;
+import com.team03.monew.repository.SubscriptionRepository;
 import com.team03.monew.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.crossstore.ChangeSetPersister;
+import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -19,6 +29,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationService {
   private final NotificationRepository notificationRepository;
   private final UserRepository userRepository;
+  private final SubscriptionRepository subscriptionRepository;
+
+
 
   @Transactional
   public CursorPageResponseNotificationDto getNotifications(UUID userId, UUID cursor, LocalDateTime after, int limit) {
@@ -50,5 +63,49 @@ public class NotificationService {
         .orElseThrow(() -> new RuntimeException("알림을 찾을 수 없습니다."));
     notification.setChecked(true);
     notification.setUpdatedAt(LocalDateTime.now());
+  }
+
+  @Transactional
+  public void notifyInterestNews(Interest interest, int articleCount) {
+    List<User> subscribers = subscriptionRepository.findAllByInterest(interest);
+
+    for (User user : subscribers) {
+      String content = String.format("[%s]와 관련된 기사가 %d건 등록되었습니다.", interest.getName(),
+          articleCount);
+
+      Notification notification = Notification.builder()
+          .user(user)
+          .content(content)
+          .relatedType(Notification.ResourceType.INTEREST)
+          .relatedId(interest.getId())
+          .checked(false)
+          .createdAt(LocalDateTime.now())
+          .updatedAt(LocalDateTime.now())
+          .build();
+
+      notificationRepository.save(notification);
+    }
+  }
+
+  public void notifyCommentLiked(UUID receiverUserId, UUID commentId) {
+    User receiver = userRepository.findById(receiverUserId)
+        .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND,new ErrorDetail(
+            "User","receiverUserId","user"
+        ), ExceptionType.INTEREST));
+
+
+    String content = String.format("[%s]님이 나의 댓글을 좋아합니다.", receiver.getNickname());
+
+    Notification notification = Notification.builder()
+        .user(receiver)
+        .content(content)
+        .relatedType(Notification.ResourceType.COMMENT)
+        .relatedId(commentId)
+        .checked(false)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    notificationRepository.save(notification);
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #73 

---

## 📌 작업 개요
<!-- 어떤 작업을 했는지 간단하게 요약해주세요 -->
- NotificationService에 notifyInterestNews, notifyCommentLiked 구현
- SubscriptionRepository에 findAllByInterest 구현
- InterestService에 getInterestKeywordMap추가

---

## 🛠 작업 상세 내용
<!-- 주요 작업 내용을 리스트로 정리해주세요 -->
- getInterestKeywordMap을 활용하여 rssController에 관심사 관련 기사 등록 될때 마다 등록 횟수 카운트-> 카운트,관심사 맵 생성
- 생성된 맵을 notifyInterestNews에 전달
- findAllByInterest 로 notifyInterestNews 내에서 notification 빌더에 필요한 user 가져오기
- 댓글 좋아요 누를 때마다 알림 생성되게 notifyCommentLiked를 CommentController 내부 addCommentLiked에 적용
