### PR TITLE
fix: 프론트엔드 요청 정보에 맞춰서 publishDate를 처리하도록 변경

### DIFF
--- a/src/main/java/com/team03/monew/repository/impl/NewsArticleRepositoryImpl.java
+++ b/src/main/java/com/team03/monew/repository/impl/NewsArticleRepositoryImpl.java
@@ -74,10 +74,10 @@ public class NewsArticleRepositoryImpl implements NewsArticleRepositoryCustom {
         Order order = direction.equalsIgnoreCase("ASC") ? Order.ASC : Order.DESC;
 
         return switch (orderBy) {
-            case "date" -> new OrderSpecifier<>(order, article.date);
+            case "publishDate" -> new OrderSpecifier<>(order, article.date);
             case "commentCount" -> new OrderSpecifier<>(order, article.comments.size());
             case "viewCount" -> new OrderSpecifier<>(order, article.viewCount);
-            default -> throw new CustomException(ErrorCode.INVALID_TYPE_VALUE, new ErrorDetail("date, commentCount, vieCount", "orderBy", orderBy), ExceptionType.NEWSARTICLE);
+            default -> throw new CustomException(ErrorCode.INVALID_TYPE_VALUE, new ErrorDetail("publishdate, commentCount, viewCount", "orderBy", orderBy), ExceptionType.NEWSARTICLE);
         };
     }
 }


### PR DESCRIPTION
---

## 📌 작업 개요
NewsArticleRepositoryImpl의 switch-case문에 잘못된 입력이 있어서 변경(date -> publishDate)

---

## 🛠 작업 상세 내용
![image](https://github.com/user-attachments/assets/e58e48ca-33c3-4c30-984f-bba88b9656e4)

임의의 데이터를 입력한 후, 디버그 모드에서 NewsArticleController.java - getArticles(수정한 부분을 활용하는 메서드)가 정상 작동하여 
content, nextCursor,nextAfter, size, totalElements, hasNext를 정상적으로 가져오는 것을 확인했습니다.
