### PR TITLE
Feature/82 환경 별 application.yml 분리 및 dev/prod 설정 구성

### DIFF
--- a/src/main/java/com/team03/monew/controller/NewsArticleController.java
+++ b/src/main/java/com/team03/monew/controller/NewsArticleController.java
@@ -38,7 +38,7 @@ public class NewsArticleController {
     @PostMapping("/{articleId}/article-views")
     public ResponseEntity<ArticleViewDto> saveArticleView(
         @PathVariable UUID articleId,
-        @RequestHeader("MoNew-Request-User-ID") UUID userId
+        @RequestHeader("Monew-Request-User-ID") UUID userId
     ) {
         ArticleViewDto dto = newsArticleService.saveArticleView(articleId, userId);
         return ResponseEntity.ok(dto);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/your_db
+    username: your_user
+    password: your_password
+  jpa:
+    hibernate:
+      ddl-auto: create  # create/update
+
+logging:
+  level:
+    root: INFO
+    com.myapp: DEBUG               # 코드 디버깅 위해 상세하게
+    org.springframework.web: DEBUG  # HTTP 요청/응답 흐름까지
+    org.hibernate.SQL: DEBUG       # 실행되는 SQL 보이게
+    org.hibernate.type: TRACE      # SQL 파라미터 값까지 추적
+
+naver:
+  api:
+    client-id: ${NAVER_API_CLIENT_ID}
+    client-secret: ${NAVER_API_CLIENT_SECRET}
+
+aws:
+  s3:
+    access-key: ${AWS_S3_ACCESS_KEY}
+    secret-key: ${AWS_S3_SECRET_KEY}
+    region: ${AWS_S3_REGION}
+    bucket: ${AWS_S3_BUCKET}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    url: ${PROD_DB_URL}
+    username: ${PROD_DB_USER}
+    password: ${PROD_DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: validate
+
+logging:
+  level:
+    root: WARN
+    com.myapp: INFO                # 핵심 비즈니스 로직만
+    org.springframework: WARN      # 프레임워크 관련 경고 이상만
+    org.hibernate.SQL: OFF         # SQL 로그 완전 비활성화
+    org.hibernate.type: OFF        # 바인딩 로그 비활성화
+
+naver:
+  api:
+    client-id: ${NAVER_API_CLIENT_ID}
+    client-secret: ${NAVER_API_CLIENT_SECRET}
+
+aws:
+  s3:
+    access-key: ${AWS_S3_ACCESS_KEY}
+    secret-key: ${AWS_S3_SECRET_KEY}
+    region: ${AWS_S3_REGION}
+    bucket: ${AWS_S3_BUCKET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,31 +1,16 @@
 spring:
     application:
         name: monew
-    datasource:
-        url: jdbc:postgresql://localhost:5432/your_db
-        username: your_user
-        password: your_password
-    task:
-        scheduling:
-            pool:
-                size: 1
+    profiles:
+        active: dev  # 운영 환경에서는 'spring.profiles.active=prod'를 환경 변수 또는 실행 옵션(-Dspring.profiles.active=prod)으로 지정하여 prod 설정을 활성화합니다.
 
     jpa:
-        hibernate:
-            ddl-auto: create  # 또는 update, validate 등
         properties:
             hibernate:
                 format_sql: true
                 dialect: org.hibernate.dialect.PostgreSQLDialect
 
-naver:
-    api:
-        client-id: ${NAVER_API_CLIENT_ID}
-        client-secret: ${NAVER_API_CLIENT_SECRET}
-
-aws:
-    s3:
-        access-key: ${AWS_S3_ACCESS_KEY}
-        secret-key: ${AWS_S3_SECRET_KEY}
-        region: ${AWS_S3_REGION}
-        bucket: ${AWS_S3_BUCKET}
+task:
+    scheduling:
+        pool:
+            size: 1


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #82

---

## 📌 작업 개요
- 환경 별 설정 관리를 위해 application.yml 파일을 dev, prod로 분리하였습니다.
- 기본 profile은 dev로 설정되어 있습니다.

---

## 🛠 작업 상세 내용
- 로깅 설정을 환경별로 다르게 분리 (dev: DEBUG / prod: INFO~WARN)
- JPA `ddl-auto` 설정 분리 (`create` vs `validate`)
- Naver API, AWS S3 관련 설정도 환경별로 구성(현재는 이름은 같고 값만 분리)
- 환경 변수(`ENV`)를 통해 민감 정보 주입 방식 유지

## 📝 기타 참고 사항

- 운영 서버에서는 `-Dspring.profiles.active=prod` 또는 `SPRING_PROFILES_ACTIVE=prod`로 prod 설정 활성화 필요
- NewsArticleService의 오탈자도 수정하였습니다.(MoNew -> Monew)
