### PR TITLE
Fix/86 댓글 로딩 및 생성 오류 수정

### DIFF
--- a/src/main/java/com/team03/monew/controller/CommentController.java
+++ b/src/main/java/com/team03/monew/controller/CommentController.java
@@ -40,7 +40,7 @@ public class CommentController {
     @GetMapping()
     public CursorPageResponseCommentDto<CommentDto> getCommentsWithCursorPaging(
             @RequestParam("articleId") UUID articleId,
-            @RequestParam("orderBy") OrderBy orderBy,
+        @RequestParam String orderBy,
             @RequestParam("direction") SortDirection direction,
             @RequestParam(value = "cursor", required = false) UUID cursor,
             @RequestParam(value = "after", required = false)
@@ -49,7 +49,8 @@ public class CommentController {
             @Min(1) @Max(100) int limit,
             @RequestHeader("Monew-Request-User-ID") UUID userId
     ) {
-        return commentService.commentCursorPage(articleId, orderBy, direction, cursor, after, limit, userId);
+        OrderBy orderByEnum = OrderBy.fromValue(orderBy);
+        return commentService.commentCursorPage(articleId, orderByEnum, direction, cursor, after, limit, userId);
     }
 
 

--- a/src/main/java/com/team03/monew/dto/comment/request/CommentRegisterRequest.java
+++ b/src/main/java/com/team03/monew/dto/comment/request/CommentRegisterRequest.java
@@ -12,5 +12,5 @@ public record CommentRegisterRequest(
         UUID userId,
 
         @NotBlank(message = "댓글 내용은 필수입니다.")
-        String comment
+        String content
 ) {}

--- a/src/main/java/com/team03/monew/service/CommentServiceImpl.java
+++ b/src/main/java/com/team03/monew/service/CommentServiceImpl.java
@@ -81,7 +81,7 @@ public class CommentServiceImpl implements CommentService {
         User user = entityFinder.getUserOrThrow(request.userId());
         NewsArticle article = entityFinder.getNewsArticleOrThrow(request.articleId());
 
-        Comment comment = CommentMapper.toComment(request.comment(), article, user);
+        Comment comment = CommentMapper.toComment(request.content(), article, user);
         return CommentMapper.toCommentDto(commentRepository.save(comment));
     }
 

--- a/src/main/java/com/team03/monew/util/OrderBy.java
+++ b/src/main/java/com/team03/monew/util/OrderBy.java
@@ -1,5 +1,10 @@
 package com.team03.monew.util;
 
+import com.team03.monew.exception.CustomException;
+import com.team03.monew.exception.ErrorCode;
+import com.team03.monew.exception.ErrorDetail;
+import com.team03.monew.exception.ExceptionType;
+
 public enum OrderBy {
 
     CREATED_AT("createdAt"),
@@ -13,5 +18,15 @@ public enum OrderBy {
 
     public String getValue() {
         return value;
+    }
+
+    public static OrderBy fromValue(String value) {
+        for (OrderBy orderBy : OrderBy.values()) {
+            if (orderBy.value.equalsIgnoreCase(value)) {
+                return orderBy;
+            }
+        }
+        ErrorDetail detail = new ErrorDetail("OrderBy(createdAt, likeCount)", "orderBy", value);
+        throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, detail, ExceptionType.COMMENT);
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #86

---

## 📌 작업 개요
**[댓글 등록 오류 수정 - CommentRegisterRequest.java, CommentServiceImpl.java]**
댓글 등록 API 요청 시 프론트에서 `content` 필드로 값을 전달하고 있었으나,  
백엔드 DTO에서는 `comment` 필드로 선언되어 있어 `@NotBlank` 유효성 검사가 실패하고 있어 수정하였습니다.
![image](https://github.com/user-attachments/assets/ef7f07a4-3c97-4c54-a7e9-e68630adcb2e)


**[댓글 로딩 오류 수정 - CommentController.java, OrderBy.java]**
프론트엔드에서 `orderBy=createdAt` 또는 `likeCount`와 같은 camelCase 문자열을 요청 파라미터로 전달했을 때,  
백엔드에서 `@RequestParam OrderBy orderBy`로 처리하는 과정에서 `MethodArgumentTypeMismatchException`이 발생하였습니다.

기존 `OrderBy` enum은 아래와 같이 정의되어 있었습니다:

```java
public enum OrderBy {
    CREATED_AT("createdAt"),
    LIKE_COUNT("likeCount");
}
```
하지만 Spring의 @RequestParam은 내부적으로 Enum.valueOf(...)를 사용하여
문자열을 enum으로 변환하기 때문에 enum의 name() 값과 정확히 일치해야 변환이 가능합니다.

따라서 오류가 발생했었고, camelCase로 들어오는 값을 `value` 필드 기준으로 비교하도록 변경하였습니다.

