### PR TITLE
Feature/63 QueryDSL Fetch Join 을 통한 활동 내역 관리 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 !**/src/test/**/build/
 .DS_Store
 docker-compose.yml
+./logs
 
 ### STS ###
 .apt_generated

--- a/src/main/java/com/team03/monew/controller/ActivityController.java
+++ b/src/main/java/com/team03/monew/controller/ActivityController.java
@@ -1,7 +1,8 @@
 package com.team03.monew.controller;
 
 import com.team03.monew.dto.user.UserActivityDto;
-import com.team03.monew.service.ActivityService;
+import com.team03.monew.service.activity.ActivityService;
+import com.team03.monew.service.activity.ActivityServiceRouter;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,13 +17,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ActivityController {
 
-    private final ActivityService activityService;
+    private final ActivityServiceRouter activityServiceRouter;
 
     @GetMapping("/{userId}")
     public ResponseEntity<UserActivityDto> getUserActivity(
         @PathVariable UUID userId,
-        @RequestHeader("Monew-Request-User-ID") UUID requesterId
+        @RequestHeader("MoNew-Request-User-ID") UUID requesterId
     ) {
+        ActivityService activityService = activityServiceRouter.resolve();
         UserActivityDto response = activityService.getUserActivity(userId, requesterId);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/team03/monew/repository/ArticleViewRepository.java
+++ b/src/main/java/com/team03/monew/repository/ArticleViewRepository.java
@@ -3,12 +3,15 @@ package com.team03.monew.repository;
 import com.team03.monew.entity.ArticleView;
 import com.team03.monew.entity.NewsArticle;
 import com.team03.monew.entity.User;
+import com.team03.monew.repository.custom.ArticleViewRepositoryCustom;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID> {
+public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID>,
+    ArticleViewRepositoryCustom {
+
     Optional<ArticleView> findByArticleAndUser(NewsArticle article, User user);
 
     void deleteByArticle(NewsArticle article);

--- a/src/main/java/com/team03/monew/repository/CommentLikeRepository.java
+++ b/src/main/java/com/team03/monew/repository/CommentLikeRepository.java
@@ -3,12 +3,14 @@ package com.team03.monew.repository;
 import com.team03.monew.entity.Comment;
 import com.team03.monew.entity.CommentLike;
 import com.team03.monew.entity.User;
+import com.team03.monew.repository.custom.CommentLikeRepositoryCustom;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> {
+public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID>,
+    CommentLikeRepositoryCustom {
     boolean existsByCommentAndUser(Comment comment, User user);
 
     Optional<CommentLike> findByCommentAndUser(Comment comment, User user);

--- a/src/main/java/com/team03/monew/repository/CommentRepository.java
+++ b/src/main/java/com/team03/monew/repository/CommentRepository.java
@@ -2,12 +2,13 @@ package com.team03.monew.repository;
 
 import com.team03.monew.entity.Comment;
 import com.team03.monew.entity.User;
+import com.team03.monew.repository.custom.CommentRepositoryCustom;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID>,
-    com.team03.monew.repository.custom.CommentRepositoryCustom {
+    CommentRepositoryCustom {
 
     List<Comment> findTop10ByUserOrderByCreatedAtDesc(User user);
 

--- a/src/main/java/com/team03/monew/repository/SubscriptionRepository.java
+++ b/src/main/java/com/team03/monew/repository/SubscriptionRepository.java
@@ -3,6 +3,7 @@ package com.team03.monew.repository;
 import com.team03.monew.entity.Interest;
 import com.team03.monew.entity.Subscription;
 import com.team03.monew.entity.User;
+import com.team03.monew.repository.custom.SubscriptionRepositoryCustom;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -10,7 +11,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
+public interface SubscriptionRepository extends JpaRepository<Subscription, UUID>,
+    SubscriptionRepositoryCustom {
 
     Optional<Subscription> findByUserIdAndInterestId(UUID userId, UUID interestId);
 

--- a/src/main/java/com/team03/monew/repository/custom/ArticleViewRepositoryCustom.java
+++ b/src/main/java/com/team03/monew/repository/custom/ArticleViewRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.team03.monew.repository.custom;
+
+import com.team03.monew.entity.ArticleView;
+import com.team03.monew.entity.User;
+import java.util.List;
+
+public interface ArticleViewRepositoryCustom {
+
+    List<ArticleView> findTop10ByUserWithArticle(User user);
+
+}

--- a/src/main/java/com/team03/monew/repository/custom/CommentLikeRepositoryCustom.java
+++ b/src/main/java/com/team03/monew/repository/custom/CommentLikeRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.team03.monew.repository.custom;
+
+import com.team03.monew.entity.CommentLike;
+import com.team03.monew.entity.User;
+import java.util.List;
+
+public interface CommentLikeRepositoryCustom {
+
+    List<CommentLike> findTop10ByUserWithCommentAndNewsAndUser(User user);
+
+}

--- a/src/main/java/com/team03/monew/repository/custom/CommentRepositoryCustom.java
+++ b/src/main/java/com/team03/monew/repository/custom/CommentRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.team03.monew.repository.custom;
 
 import com.team03.monew.entity.Comment;
+import com.team03.monew.entity.User;
 import com.team03.monew.util.OrderBy;
 import com.team03.monew.util.SortDirection;
 import java.time.LocalDateTime;
@@ -18,4 +19,6 @@ public interface CommentRepositoryCustom {
             int limit,
             UUID requesterId
     );
+
+    List<Comment> findTop10ByUserWithNewsAndUser(User user);
 }

--- a/src/main/java/com/team03/monew/repository/custom/SubscriptionRepositoryCustom.java
+++ b/src/main/java/com/team03/monew/repository/custom/SubscriptionRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.team03.monew.repository.custom;
+
+import com.team03.monew.entity.Subscription;
+import com.team03.monew.entity.User;
+import java.util.List;
+
+public interface SubscriptionRepositoryCustom {
+
+    List<Subscription> findByUserFetchInterest(User user);
+}

--- a/src/main/java/com/team03/monew/repository/impl/ArticleViewRepositoryImpl.java
+++ b/src/main/java/com/team03/monew/repository/impl/ArticleViewRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.team03.monew.repository.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team03.monew.entity.ArticleView;
+import com.team03.monew.entity.QArticleView;
+import com.team03.monew.entity.QNewsArticle;
+import com.team03.monew.entity.User;
+import com.team03.monew.repository.custom.ArticleViewRepositoryCustom;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ArticleViewRepositoryImpl implements ArticleViewRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ArticleView> findTop10ByUserWithArticle(User user) {
+        QArticleView view = QArticleView.articleView;
+        QNewsArticle article = QNewsArticle.newsArticle;
+
+        return queryFactory
+            .selectFrom(view)
+            .join(view.article, article).fetchJoin()
+            .where(view.user.eq(user))
+            .orderBy(view.createdAt.desc())
+            .limit(10)
+            .fetch();
+    }
+}

--- a/src/main/java/com/team03/monew/repository/impl/CommentLikeRepositoryImpl.java
+++ b/src/main/java/com/team03/monew/repository/impl/CommentLikeRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.team03.monew.repository.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team03.monew.entity.CommentLike;
+import com.team03.monew.entity.QComment;
+import com.team03.monew.entity.QCommentLike;
+import com.team03.monew.entity.QNewsArticle;
+import com.team03.monew.entity.QUser;
+import com.team03.monew.entity.User;
+import com.team03.monew.repository.custom.CommentLikeRepositoryCustom;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentLikeRepositoryImpl implements CommentLikeRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CommentLike> findTop10ByUserWithCommentAndNewsAndUser(User user) {
+        QCommentLike like = QCommentLike.commentLike;
+        QComment comment = QComment.comment;
+        QNewsArticle news = QNewsArticle.newsArticle;
+        QUser commentUser = QUser.user;
+
+        return queryFactory
+            .selectFrom(like)
+            .join(like.comment, comment).fetchJoin()
+            .join(comment.news, news).fetchJoin()
+            .join(comment.user, commentUser).fetchJoin()
+            .where(like.user.eq(user))
+            .orderBy(like.createdAt.desc())
+            .limit(10)
+            .fetch();
+    }
+}

--- a/src/main/java/com/team03/monew/repository/impl/CommentRepositoryImpl.java
+++ b/src/main/java/com/team03/monew/repository/impl/CommentRepositoryImpl.java
@@ -4,6 +4,9 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.team03.monew.entity.Comment;
 import com.team03.monew.entity.QComment;
+import com.team03.monew.entity.QNewsArticle;
+import com.team03.monew.entity.QUser;
+import com.team03.monew.entity.User;
 import com.team03.monew.repository.custom.CommentRepositoryCustom;
 import com.team03.monew.util.OrderBy;
 import com.team03.monew.util.SortDirection;
@@ -42,4 +45,22 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                 .limit(limit)
                 .fetch();
     }
+
+    @Override
+    public List<Comment> findTop10ByUserWithNewsAndUser(User user) {
+
+        QComment comment = QComment.comment;
+        QNewsArticle news = QNewsArticle.newsArticle;
+        QUser commentUser = QUser.user;
+
+        return queryFactory
+            .selectFrom(comment)
+            .join(comment.news, news).fetchJoin()
+            .join(comment.user, commentUser).fetchJoin()
+            .where(comment.user.eq(user))
+            .orderBy(comment.createdAt.desc())
+            .limit(10)
+            .fetch();
+    }
+
 }

--- a/src/main/java/com/team03/monew/repository/impl/SubscriptionRepositoryImpl.java
+++ b/src/main/java/com/team03/monew/repository/impl/SubscriptionRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.team03.monew.repository.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team03.monew.entity.QInterest;
+import com.team03.monew.entity.QSubscription;
+import com.team03.monew.entity.Subscription;
+import com.team03.monew.entity.User;
+import com.team03.monew.repository.custom.SubscriptionRepositoryCustom;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SubscriptionRepositoryImpl implements SubscriptionRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Subscription> findByUserFetchInterest(User user) {
+        QSubscription subscription = QSubscription.subscription;
+        QInterest interest = QInterest.interest;
+
+        return queryFactory
+            .selectFrom(subscription)
+            .join(subscription.interest, interest).fetchJoin()  // 즉시 로딩 설정
+            .where(subscription.user.eq(user))
+            .orderBy(subscription.createdAt.desc())
+            .fetch();
+    }
+}

--- a/src/main/java/com/team03/monew/service/activity/ActivityService.java
+++ b/src/main/java/com/team03/monew/service/activity/ActivityService.java
@@ -1,6 +1,6 @@
-package com.team03.monew.service;
+package com.team03.monew.service.activity;
 
-import com.team03.monew.dto.user.UserActivityDto;
+import  com.team03.monew.dto.user.UserActivityDto;
 import java.util.UUID;
 
 public interface ActivityService {

--- a/src/main/java/com/team03/monew/service/activity/ActivityServiceFetchJoinImpl.java
+++ b/src/main/java/com/team03/monew/service/activity/ActivityServiceFetchJoinImpl.java
@@ -1,0 +1,87 @@
+package com.team03.monew.service.activity;
+
+import com.team03.monew.dto.comment.response.CommentActivityDto;
+import com.team03.monew.dto.comment.response.CommentLikeActivityDto;
+import com.team03.monew.dto.newsArticle.mapper.ArticleViewMapper;
+import com.team03.monew.dto.newsArticle.response.ArticleViewDto;
+import com.team03.monew.dto.subscription.SubscriptionDto;
+import com.team03.monew.dto.subscription.mapper.SubsciptionMapper;
+import com.team03.monew.dto.user.UserActivityDto;
+import com.team03.monew.entity.User;
+import com.team03.monew.exception.CustomException;
+import com.team03.monew.exception.ErrorCode;
+import com.team03.monew.exception.ErrorDetail;
+import com.team03.monew.exception.ExceptionType;
+import com.team03.monew.repository.ArticleViewRepository;
+import com.team03.monew.repository.CommentLikeRepository;
+import com.team03.monew.repository.CommentRepository;
+import com.team03.monew.repository.SubscriptionRepository;
+import com.team03.monew.repository.UserRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ActivityServiceFetchJoinImpl implements ActivityService {
+
+    private final UserRepository userRepository;
+    private final SubscriptionRepository subscriptionRepository;
+    private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final ArticleViewRepository articleViewRepository;
+
+    @Override
+    public UserActivityDto getUserActivity(UUID userId, UUID requesterId) {
+        if (!userId.equals(requesterId)) {
+            ErrorDetail detail = new ErrorDetail("USER", "userId", requesterId.toString());
+            throw new CustomException(ErrorCode.FORBIDDEN, detail, ExceptionType.USER);
+        }
+
+        // 1. 사용자 정보 조회
+        User user = userRepository.findByIdAndDeletedFalse(userId).orElseThrow(() -> {
+            ErrorDetail detail = new ErrorDetail("USER", "userId", userId.toString());
+            return new CustomException(ErrorCode.FORBIDDEN, detail, ExceptionType.USER);
+        });
+
+        // 2. 구독 중인 관심사 조회 (구독 최신순 정렬)
+        List<SubscriptionDto> subscriptions = subscriptionRepository
+            .findByUserFetchInterest(user)
+            .stream()
+            .map(SubsciptionMapper::from)
+            .toList();
+
+        // 3. 최근 작성한 댓글 최대 10건 조회 (최신순)
+        List<CommentActivityDto> comments = commentRepository
+            .findTop10ByUserWithNewsAndUser(user)
+            .stream()
+            .map(CommentActivityDto::from)
+            .toList();
+
+        // 4. 최근 좋아요를 누른 댓글 최대 10건 조회 (최신순)
+        List<CommentLikeActivityDto> commentLikes = commentLikeRepository
+            .findTop10ByUserWithCommentAndNewsAndUser(user)
+            .stream()
+            .map(CommentLikeActivityDto::from)
+            .toList();
+
+        // 5. 최근 본 뉴스 기사 최대 10건 조회 (최신순)
+        List<ArticleViewDto> articleViews = articleViewRepository
+            .findTop10ByUserWithArticle(user)
+            .stream()
+            .map(ArticleViewMapper::toDto)
+            .toList();
+
+        return new UserActivityDto(
+            user.getId(),
+            user.getEmail(),
+            user.getNickname(),
+            user.getCreatedAt(),
+            subscriptions,
+            comments,
+            commentLikes,
+            articleViews
+        );
+    }
+}

--- a/src/main/java/com/team03/monew/service/activity/ActivityServiceLazyImpl.java
+++ b/src/main/java/com/team03/monew/service/activity/ActivityServiceLazyImpl.java
@@ -1,4 +1,4 @@
-package com.team03.monew.service;
+package com.team03.monew.service.activity;
 
 import com.team03.monew.dto.comment.response.CommentActivityDto;
 import com.team03.monew.dto.comment.response.CommentLikeActivityDto;
@@ -24,7 +24,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class ActivityServiceImpl implements ActivityService {
+public class ActivityServiceLazyImpl implements ActivityService {
 
     private final UserRepository userRepository;
     private final SubscriptionRepository subscriptionRepository;

--- a/src/main/java/com/team03/monew/service/activity/ActivityServiceMongoImpl.java
+++ b/src/main/java/com/team03/monew/service/activity/ActivityServiceMongoImpl.java
@@ -1,0 +1,16 @@
+package com.team03.monew.service.activity;
+
+import com.team03.monew.dto.user.UserActivityDto;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ActivityServiceMongoImpl implements ActivityService {
+
+    @Override
+    public UserActivityDto getUserActivity(UUID userId, UUID requesterId) {
+        return null;
+    }
+}

--- a/src/main/java/com/team03/monew/service/activity/ActivityServiceRouter.java
+++ b/src/main/java/com/team03/monew/service/activity/ActivityServiceRouter.java
@@ -1,0 +1,26 @@
+package com.team03.monew.service.activity;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ActivityServiceRouter {
+
+    // 기본 전략을 yml 파일에서 가져옴
+    @Value("${custom.activity-service-strategy}")
+    private String strategy;
+
+    private final ActivityServiceLazyImpl lazyService;
+    private final ActivityServiceFetchJoinImpl fetchService;
+    private final ActivityServiceMongoImpl mongoService;
+
+    public ActivityService resolve() {
+        return switch (strategy.toLowerCase()) {
+            case "fetch" -> fetchService;
+            case "mongo" -> mongoService;
+            default -> lazyService;
+        };
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,6 +15,9 @@ logging:
     org.hibernate.SQL: DEBUG
     org.hibernate.type: TRACE
 
+custom:
+  activity-service-strategy: lazy  # 또는 fetch, mongo (실험 시 변경)
+
 naver:
   api:
     client-id: ${NAVER_API_CLIENT_ID}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -15,6 +15,9 @@ logging:
     org.hibernate.SQL: OFF
     org.hibernate.type: OFF
 
+custom:
+  activity-service-strategy: lazy  # 또는 fetch, mongo (실험 시 변경)
+
 naver:
   api:
     client-id: ${NAVER_API_CLIENT_ID}


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #63

---

## 📌 작업 개요
<!-- 어떤 작업을 했는지 간단하게 요약해주세요 -->
- 사용자 활동 내역 조회 API 구현
- QueryDSL + Fetch Join 기반 성능 최적화 적용
- 전략별 분기 처리 기반 구조 설계 (lazy, fetch, mongo)


---

## 🛠 작업 상세 내용
<!-- 주요 작업 내용을 리스트로 정리해주세요 -->
- ActivityServiceLazyImpl → N+1 기반 기본 전략 구성
- QueryDSL 기반 ActivityServiceFetchJoinImpl 구현
- 구독 관심사, 댓글, 좋아요 댓글, 기사 뷰 각각 fetch join 적용
- 전략별 분기 처리: application.yml 설정값(custom.activity-service-strategy)에 따라 서비스 분기

