### PR TITLE
fix: 등록된 관심사를 통해 네이버 기사를 가져오도록 설정 및 요약 저장 길이 설정

### DIFF
--- a/src/main/java/com/team03/monew/entity/NewsArticle.java
+++ b/src/main/java/com/team03/monew/entity/NewsArticle.java
@@ -29,7 +29,7 @@ public class NewsArticle {
   @Column(nullable = false)
   private String source;
 
-  @Column(columnDefinition = "text", nullable = false, unique = true)
+  @Column(length = 2000, nullable = false, unique = true)
   private String originalLink;
 
   @Column(nullable = false)
@@ -38,6 +38,7 @@ public class NewsArticle {
   @Column(nullable = false)
   private LocalDateTime date;
 
+  @Column(length = 2000)
   private String summary;
 
   @ManyToMany

--- a/src/main/java/com/team03/monew/external/naver/NaverApiCollector.java
+++ b/src/main/java/com/team03/monew/external/naver/NaverApiCollector.java
@@ -92,6 +92,11 @@ public class NaverApiCollector {
                 if (item == null)
                     continue; // 예외 케이스 방지
 
+                // 제목이나 설명에 키워드가 포함되어 있는지 확인
+                if (!newsArticleService.containsKeyword(item.getTitle(), item.getDescription())) {
+                    continue; // 키워드가 포함되어 있지 않으면 저장하지 않음
+                }
+
                 NewsArticleRequestDto dto = item.toDto(new ArrayList<>(interestIds));
                 newsArticleService.saveIfNotExists(dto);
             }


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #100

---

## 📌 작업 개요
- 기존에 누락되어 있던 관심사 필터링 조건 추가(Naver API)
- summary 길이 문제로 가끔 오류가 발생해서 넉넉하게 설정


