### PR TITLE
Feat/104 Spring Batch 기반 뉴스 수집 구조 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,8 @@ dependencies {
     // AWS S3 SDK 의존성
     implementation 'software.amazon.awssdk:s3:2.31.7'
 
-
+    // 배치 사용을 위한 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/team03/monew/batch/config/NewsCollectJobConfig.java
+++ b/src/main/java/com/team03/monew/batch/config/NewsCollectJobConfig.java
@@ -1,0 +1,57 @@
+package com.team03.monew.batch.config;
+
+import com.team03.monew.batch.processor.NewsArticleProcessor;
+import com.team03.monew.batch.reader.NaverNewsReader;
+import com.team03.monew.batch.reader.RssNewsReader;
+import com.team03.monew.batch.writer.NewsArticleWriter;
+import com.team03.monew.dto.newsArticle.request.NewsArticleRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class NewsCollectJobConfig {
+    // 전체 job 구성
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    private final NaverNewsReader naverNewsReader;
+    private final RssNewsReader rssNewsReader;
+    private final NewsArticleWriter newsArticleWriter;
+    private final NewsArticleProcessor newsArticleProcessor;
+
+    @Bean
+    public Job newsCollectJob() {
+        return new JobBuilder("newsCollectJob", jobRepository)
+            .start(naverStep())
+            .next(rssStep())
+            .build();
+    }
+
+    @Bean
+    public Step naverStep() {
+        return new StepBuilder("naverStep", jobRepository)
+            .<NewsArticleRequestDto, NewsArticleRequestDto>chunk(10, transactionManager)
+            .reader(naverNewsReader)
+            .processor(newsArticleProcessor)
+            .writer(newsArticleWriter)
+            .build();
+    }
+
+    @Bean
+    public Step rssStep() {
+        return new StepBuilder("rssStep", jobRepository)
+            .<NewsArticleRequestDto, NewsArticleRequestDto>chunk(10, transactionManager)
+            .reader(rssNewsReader)
+            .processor(newsArticleProcessor)
+            .writer(newsArticleWriter)
+            .build();
+    }
+}

--- a/src/main/java/com/team03/monew/batch/processor/NewsArticleProcessor.java
+++ b/src/main/java/com/team03/monew/batch/processor/NewsArticleProcessor.java
@@ -1,0 +1,66 @@
+package com.team03.monew.batch.processor;
+
+import com.team03.monew.dto.newsArticle.request.NewsArticleRequestDto;
+import com.team03.monew.entity.Interest;
+import com.team03.monew.service.InterestService;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NewsArticleProcessor implements
+    ItemProcessor<NewsArticleRequestDto, NewsArticleRequestDto> {
+
+    private final InterestService interestService;
+
+    @Override
+    public NewsArticleRequestDto process(NewsArticleRequestDto dto) {
+        // summary가 비어있거나 깨졌으면 title로 대체
+        String summary = cleanOrFallbackSummary(dto.summary(), dto.title());
+
+        // 키워드 강조 적용
+        Map<Interest, List<String>> interestKeywordMap = interestService.getInterestKeywordMap();
+        List<String> matchedKeywords = interestKeywordMap.entrySet().stream()
+            .filter(e -> dto.interestIds().contains(e.getKey().getId()))
+            .flatMap(e -> e.getValue().stream())
+            .distinct()
+            .toList();
+
+        String highlightedTitle = highlightKeywords(dto.title(), matchedKeywords);
+        String highlightedSummary = highlightKeywords(summary, matchedKeywords);
+
+        // 새로운 DTO로 반환 (record는 불변이므로 새로 생성 필요)
+        return new NewsArticleRequestDto(
+            highlightedTitle,
+            dto.originalLink(),
+            highlightedSummary,
+            dto.date(),
+            dto.source(),
+            dto.interestIds()
+        );
+    }
+
+    private String cleanOrFallbackSummary(String summary, String fallback) {
+        if (summary == null || summary.isBlank() || summary.length() < 10 || containsBrokenChars(summary)) {
+            return fallback;
+        }
+        return summary;
+    }
+
+    private boolean containsBrokenChars(String text) {
+        return text.contains("�"); // 깨진 문자 대표 패턴
+    }
+
+    private String highlightKeywords(String text, List<String> keywords) {
+        String result = text;
+        for (String keyword : keywords) {
+            result = result.replaceAll("(?i)(" + Pattern.quote(keyword) + ")", "<b>$1</b>");
+        }
+        return result;
+    }
+}
+

--- a/src/main/java/com/team03/monew/batch/reader/NaverNewsReader.java
+++ b/src/main/java/com/team03/monew/batch/reader/NaverNewsReader.java
@@ -1,0 +1,32 @@
+package com.team03.monew.batch.reader;
+
+import com.team03.monew.dto.newsArticle.request.NewsArticleRequestDto;
+import com.team03.monew.service.news.NewsArticleService;
+import jakarta.annotation.PostConstruct;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.stereotype.Component;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class NaverNewsReader implements ItemReader<NewsArticleRequestDto> {
+    // Naver API Reader
+    private final NewsArticleService newsArticleService;
+
+    private List<NewsArticleRequestDto> articles;
+    private int currentIndex = 0;
+
+    @PostConstruct
+    public void init() {
+        // collect() 내부 로직을 리팩토링해서 아래 메서드로 추출해야 함
+        this.articles = newsArticleService.collectFromNaver();
+    }
+
+    @Override
+    public NewsArticleRequestDto read() {
+        return (currentIndex < articles.size()) ? articles.get(currentIndex++) : null;
+    }
+}

--- a/src/main/java/com/team03/monew/batch/reader/RssNewsReader.java
+++ b/src/main/java/com/team03/monew/batch/reader/RssNewsReader.java
@@ -1,0 +1,32 @@
+package com.team03.monew.batch.reader;
+
+import com.team03.monew.dto.newsArticle.request.NewsArticleRequestDto;
+import com.team03.monew.service.news.NewsArticleService;
+import jakarta.annotation.PostConstruct;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.stereotype.Component;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class RssNewsReader implements ItemReader<NewsArticleRequestDto> {
+    // RSS Reader
+    private final NewsArticleService newsArticleService;
+
+    private List<NewsArticleRequestDto> articles;
+    private int currentIndex = 0;
+
+    @PostConstruct
+    public void init() {
+        this.articles = newsArticleService.collectFromRss(); // RSS 로직 분리
+    }
+
+    @Override
+    public NewsArticleRequestDto read() {
+        return (currentIndex < articles.size()) ? articles.get(currentIndex++) : null;
+    }
+
+}

--- a/src/main/java/com/team03/monew/batch/writer/NewsArticleWriter.java
+++ b/src/main/java/com/team03/monew/batch/writer/NewsArticleWriter.java
@@ -1,0 +1,22 @@
+package com.team03.monew.batch.writer;
+
+import com.team03.monew.dto.newsArticle.request.NewsArticleRequestDto;
+import com.team03.monew.service.news.NewsArticleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NewsArticleWriter implements ItemWriter<NewsArticleRequestDto> {
+
+    private final NewsArticleService newsArticleService;
+
+    @Override
+    public void write(Chunk<? extends NewsArticleRequestDto> items) throws Exception {
+        for (NewsArticleRequestDto dto : items) {
+            newsArticleService.saveIfNotExists(dto);
+        }
+    }
+}

--- a/src/main/java/com/team03/monew/util/RSSUtils.java
+++ b/src/main/java/com/team03/monew/util/RSSUtils.java
@@ -1,0 +1,75 @@
+package com.team03.monew.util;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import org.apache.commons.text.StringEscapeUtils;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RSSUtils {
+    // localdatetime으로 변환
+    public LocalDateTime parseRfc822(String dateStr) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH);
+        ZonedDateTime zdt = ZonedDateTime.parse(dateStr, formatter);
+        return zdt.withZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+    }
+
+    // 여러 형태에 맞추어서 요약 추출
+    public String extractSummary(Element item, String fallbackTitle) {
+        String rawSummary = "";
+
+        // content:encoded 우선
+        Element encoded = item.selectFirst("content\\:encoded");
+        if (encoded != null && !encoded.text().isBlank()) {
+            rawSummary = Jsoup.parse(encoded.text()).text();
+        }
+
+        // description 백업
+        if (rawSummary.isBlank()) {
+            Element descriptionEl = item.selectFirst("description");
+            if (descriptionEl != null && !descriptionEl.text().isBlank()) {
+                rawSummary = Jsoup.parse(descriptionEl.text()).text();
+            }
+        }
+
+        // fallback
+        if (rawSummary.isBlank() || rawSummary.length() < 10 || containsBrokenChars(rawSummary)) {
+            rawSummary = fallbackTitle;
+        }
+
+        return cleanSummary(rawSummary);
+    }
+
+    public boolean containsBrokenChars(String text) {
+        return text.contains("�");
+    }
+
+    // 필터링
+    public String cleanSummary(String input) {
+        if (input == null || input.isBlank()) return "";
+
+        String cleaned = Jsoup.parse(input).text().trim();
+        cleaned = StringEscapeUtils.unescapeHtml4(cleaned);
+        try {
+            cleaned = URLDecoder.decode(cleaned, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException ignored) {}
+
+        cleaned = cleaned.replaceAll("https?://\\S+", "");
+        String[] banPhrases = {"더보기", "자세히 보기", "관련 기사", "사진=", "출처=", "영상="};
+        for (String phrase : banPhrases) {
+            cleaned = cleaned.replaceAll(".*" + phrase + ".*", "");
+        }
+
+        if (cleaned.matches(".*\\.(pdf|xls|doc)[^\\s]*.*")) return "";
+        if (cleaned.replaceAll("[^a-zA-Z가-힣0-9]", "").isBlank() || cleaned.length() < 10) return "";
+
+        return cleaned;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,11 @@ spring:
         name: monew
     profiles:
         active: dev
+    batch:
+        jdbc:
+            initialize-schema: always
+        job:
+            enabled: false  # 자동 실행 방지
 
     jpa:
         properties:


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #104

---

## 📌 작업 개요
뉴스 수집 로직을 Spring Batch 기반으로 전환하였습니다.

---

## 🛠 작업 상세 내용
- Naver API / RSS 수집 로직 Reader 분리
- summary 누락/깨짐 대체 처리 및 광고 제거
- 키워드 강조 처리 (title/summary에 <b> 태그 적용)
- Job → Step → Chunk 기반 수집 구조 구성
- Scheduler에서 JobLauncher를 통해 주기적 실행

---

## 테스트 결과
- Job 정상 실행 로그 확인
- 수집 대상 뉴스 링크 중복 저장 방지됨
- 키워드 강조 및 summary fallback 로직 정상 동작 확인
