### PR TITLE
Feature/108 (모니터링) 배치 작업 메트릭 Prometheus + Grafana 연동 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,15 @@ dependencies {
 
     // 배치 사용을 위한 의존성
     implementation 'org.springframework.boot:spring-boot-starter-batch'
+
+    // Spring Boot Actuator를 위한 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // Micrometer 매트릭 등록기 사용을 위한 의존성
+    implementation 'io.micrometer:micrometer-core'
+
+    // Prometheus 사용을 위한 의존성
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'spring-actuator'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['54.180.159.88:8080']  # 현재 EC2 public ip로 하드 코딩
+      # - targets: ['host.docker.internal:8080'] # 로컬용
+
+

--- a/src/main/java/com/team03/monew/batch/config/NewsCollectJobConfig.java
+++ b/src/main/java/com/team03/monew/batch/config/NewsCollectJobConfig.java
@@ -5,6 +5,7 @@ import com.team03.monew.batch.reader.NaverNewsReader;
 import com.team03.monew.batch.reader.RssNewsReader;
 import com.team03.monew.batch.writer.NewsArticleWriter;
 import com.team03.monew.dto.newsArticle.request.NewsArticleRequestDto;
+import com.team03.monew.metrics.JobMetricListener;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
@@ -26,10 +27,12 @@ public class NewsCollectJobConfig {
     private final RssNewsReader rssNewsReader;
     private final NewsArticleWriter newsArticleWriter;
     private final NewsArticleProcessor newsArticleProcessor;
+    private final JobMetricListener jobMetricListener;
 
     @Bean
     public Job newsCollectJob() {
         return new JobBuilder("newsCollectJob", jobRepository)
+            .listener(jobMetricListener) // 메트릭 리스너
             .start(naverStep())
             .next(rssStep())
             .build();

--- a/src/main/java/com/team03/monew/metrics/BatchJobMetrics.java
+++ b/src/main/java/com/team03/monew/metrics/BatchJobMetrics.java
@@ -1,0 +1,33 @@
+package com.team03.monew.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BatchJobMetrics {
+
+    private final MeterRegistry meterRegistry;
+
+    // job 성공 기록
+    public void recordSuccess(String jobName) {
+        meterRegistry.counter("batch.job.success.count", "job", jobName).increment();
+    }
+
+    // job 실패 기록
+    public void recordFailure(String jobName) {
+        meterRegistry.counter("batch.job.failure.count", "job", jobName).increment();
+    }
+
+    // Timer
+    public void recordDuration(String jobName, Duration duration) {
+        Timer.builder("batch.job.duration")
+            .description("Batch Job Execution Time")
+            .tag("job", jobName)
+            .register(meterRegistry)
+            .record(duration);
+    }
+}

--- a/src/main/java/com/team03/monew/metrics/JobMetricListener.java
+++ b/src/main/java/com/team03/monew/metrics/JobMetricListener.java
@@ -1,0 +1,44 @@
+package com.team03.monew.metrics;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JobMetricListener implements JobExecutionListener {
+
+    private final BatchJobMetrics batchJobMetrics;
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        String jobName = jobExecution.getJobInstance().getJobName();
+
+        LocalDateTime start = jobExecution.getStartTime();
+        LocalDateTime end = jobExecution.getEndTime();
+
+        // 시스템에 맞는 오프셋
+        ZoneOffset zoneOffset = OffsetDateTime.now().getOffset();
+
+        Duration duration = Duration.between(start.toInstant(zoneOffset), end.toInstant(zoneOffset));
+        // 실행 시간 측정
+        batchJobMetrics.recordDuration(jobName, duration);
+
+        // 성공/실패 기록
+        if (jobExecution.getStatus() == BatchStatus.COMPLETED) {
+            batchJobMetrics.recordSuccess(jobName);
+            log.info("[배치 실패] jobName: {}, duration: {}ms", jobName, duration);
+        } else {
+            batchJobMetrics.recordFailure(jobName);
+            log.info("[배치 성공] jobName: {}, duration: {}ms", jobName, duration);
+        }
+    }
+}

--- a/src/main/java/com/team03/monew/metrics/MetricWarmupRunner.java
+++ b/src/main/java/com/team03/monew/metrics/MetricWarmupRunner.java
@@ -1,0 +1,23 @@
+package com.team03.monew.metrics;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("dev")
+public class MetricWarmupRunner implements ApplicationRunner {
+
+    private final BatchJobMetrics metrics;
+
+    public MetricWarmupRunner(BatchJobMetrics metrics) {
+        this.metrics = metrics;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        metrics.recordSuccess("newsCollectJob");
+        metrics.recordFailure("newsCollectJob");
+    }
+}

--- a/src/main/java/com/team03/monew/scheduler/NewsScheduler.java
+++ b/src/main/java/com/team03/monew/scheduler/NewsScheduler.java
@@ -22,7 +22,7 @@ public class NewsScheduler {
 
     private final NewsBackupService newsBackupService;
 
-    @Scheduled(cron = "0 */1 * * * *")
+    @Scheduled(cron = "0 */10 * * * *")
     public void runBatchJob() throws Exception {
         JobParameters params = new JobParametersBuilder()
             .addLong("timestamp", System.currentTimeMillis()) // 중복 실행 방지용

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -29,3 +29,16 @@ aws:
     secret-key: ${AWS_S3_SECRET_KEY}
     region: ${AWS_S3_REGION}
     bucket: ${AWS_S3_BUCKET}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    health:
+      show-details: always
+  prometheus:
+    metrics:
+      export:
+        enabled: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -29,3 +29,17 @@ aws:
     secret-key: ${AWS_S3_SECRET_KEY}
     region: ${AWS_S3_REGION}
     bucket: ${AWS_S3_BUCKET}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus, metrics
+  endpoint:
+    health:
+      show-details: never
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,12 @@ task:
     scheduling:
         pool:
             size: 1
+
+management:
+    endpoint:
+        health:
+            show-details: never  # 기본은 상세 정보 숨김
+    endpoints:
+        web:
+            exposure:
+                include: health  # 최소한의 헬스체크만 허용


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #108

---

## 📌 작업 개요
- Spring Actuaor를 통해 로그 노출
- 커스텀 메트릭을 설정하여 배치 작업의 성공, 실패, 실행 시간 기록

---

## 🛠 작업 상세 내용
- `BatchJobMetrics`, `JobMetricListener`를 통한 커스텀 메트릭 구현
- Micrometer 기반 메트릭 수집 후 Spring Actuator 경로(`/actuator/prometheus`)로 노출
- 운영 환경에서는 Prometheus가 메트릭을 수집할 수 있도록 설정
- MetricWarmupRunner는 dev 환경에만 동작하도록 설정 (임의의 값을 추가하여 프로메테우스에 메트릭을 노출시키는 역할)
- Prometheus scrape config는 추후 운영에 맞게 EC2 IP 기반으로 수정 필요
  (향후 운영 환경에서는 Elastic IP 사용 여부나 서비스 간 내부 DNS를 활용하는 방향으로 개선 여지가 있습니다.)

## ⚠️ 운영 환경 적용 시 확인 필요 사항
- prometheus.yml의 target IP 주소 변경 필요
- Grafana가 접근 가능한 ALB 또는 퍼블릭 IP 설정 필요
- actuator endpoint 접근 권한 설정 고려 (보안)

## 목적
- 운영 배치 작업의 성공/실패 및 실행 시간 모니터링을 통해 이상 탐지 및 분석 기반 확보
- pr 이후 배포 환경에서 프로메테우스 - 그라파나 적용을 진행할 예정입니다.

actuator를 통한 커스텀 메트릭 확인(지금은 이 방법으로만 확인 가능)
http://<퍼블릭 IP 또는 도메인>:<포트>/actuator/metrics/<메트릭 이름>
![기본액츄에이터](https://github.com/user-attachments/assets/fa78efa5-f20c-40f5-9aae-799d49655c77)

프로메테우스-그라파나를 통한 커스텀 메트릭 확인(현재 pr올린 파일은 로컬에서 사용을 위한 프로메테우스, 그라파나 설정이 되어있지 않습니다.)
![그라파나](https://github.com/user-attachments/assets/398d5a16-21e3-4119-aec5-2b2ff05ddcf1)
