### PR TITLE
Feat/119 배포 환경에서 Prometheus + Grafana 모니터링을 위한 설정 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,3 +24,25 @@ jobs:
           service: your-ecs-service
           cluster: your-cluster
           wait-for-service-stability: true
+
+      # Prometheus 전용 이미지 빌드 & ECR 푸시
+      - name: Configure AWS Credentials for Prometheus
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Login to Amazon ECR (Prometheus)
+        run: |
+          aws ecr get-login-password --region ap-northeast-2 | \
+          docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-2.amazonaws.com
+
+      - name: Build Prometheus Docker Image
+        run: |
+          docker build -t prom-custom ./prometheus
+          docker tag prom-custom ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-2.amazonaws.com/monew-prometheus:latest
+
+      - name: Push Prometheus Image to ECR
+        run: |
+          docker push ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-2.amazonaws.com/monew-prometheus:latest

--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -1,0 +1,3 @@
+FROM prom/prometheus
+COPY prometheus.yml /etc/prometheus/prometheus.yml
+CMD [ "sh", "-c", "envsubst < /etc/prometheus/prometheus.yml.template > /etc/prometheus/prometheus.yml && /bin/prometheus --config.file=/etc/prometheus/prometheus.yml" ]

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -5,7 +5,7 @@ scrape_configs:
   - job_name: 'spring-actuator'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['54.180.159.88:8080']  # 현재 EC2 public ip로 하드 코딩
+      - targets: ['43.291.115.233:8080']  # 현재 EC2 public ip로 하드 코딩
       # - targets: ['host.docker.internal:8080'] # 로컬용
 
 

--- a/src/main/java/com/team03/monew/config/SecurityConfig.java
+++ b/src/main/java/com/team03/monew/config/SecurityConfig.java
@@ -6,7 +6,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -36,6 +35,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/", "/index.html", "/favicon.ico", "/assets/**").permitAll()
                 .requestMatchers("/api/users/login", "/api/users").permitAll() // 로그인, 회원가입은 누구나 가능
+                .requestMatchers("/actuator/**").permitAll() // 액츄에이터 허용
                 .anyRequest().authenticated()   // 그 외는 모두 로그인 필요(인증 필요)
             )
 


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #119

---

## 📌 작업 개요
- 프로메테우스 + 그라파나 구성을 배포 환경에서도 확인할 수 있도록 설정을 추가하였습니다.

---

## 🛠 작업 상세 내용
- 배치 작업에 대한 커스텀 메트릭 적용 이후, 배포 환경에서도 모니터링할 수 있도록 Prometheus 및 Grafana 설정 추가
- `/prometheus/Dockerfile` 작성 및 ECR 푸시 로직 CI/CD에 반영
- `.github/workflows/deploy.yml`에 Prometheus 이미지 빌드 및 푸시 스텝 추가
- EC2 Public IP 기반으로 Prometheus 타겟 하드 코딩 

## 참고 사항
- ALB 미사용 상태로, 현재는 EC2 Public IP 하드 코딩 방식으로 임시 대응(`/prometheus/prometheus.yml`)
- 이후 ALB 도입 및 Target Group 연동 시 개선 가능
- 로컬 환경에서 프로메테우스 + 그라파나를 테스트하고 싶은 경우 
  - `/prometheus/prometheus.yml`에서 로컬용 targets 활성화.
  - docker-compose 파일에 아래 내용 추가 후 dockerc-compose up -build를 통해 프로젝트 실행
```
services:
  prometheus:
    image: prom/prometheus
    ports:
      - "9090:9090"
    volumes:
      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
    restart: always

  grafana:
    image: grafana/grafana
    ports:
      - "3000:3000"
    restart: always
```
