### PR TITLE
Feature/122 bcrypt password encode 적용

### DIFF
--- a/src/main/java/com/team03/monew/config/SecurityConfig.java
+++ b/src/main/java/com/team03/monew/config/SecurityConfig.java
@@ -11,6 +11,8 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -18,12 +20,13 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
 @Configuration
-@EnableWebSecurity
+@EnableWebSecurity  //Spring Security를 활성화하겠다는 의미
 @RequiredArgsConstructor
 public class SecurityConfig {
 
     private final CustomUserDetailsService customUserDetailsService;
 
+    // Spring Security 에서 보안 설정 정의
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
@@ -48,9 +51,10 @@ public class SecurityConfig {
                 .requireExplicitSave(false)
             )
 
-
             // 커스텀 필터 등록
-            .addFilterAfter(new MoNewUserValidationFilter(), UsernamePasswordAuthenticationFilter.class);
+            // UsernamePasswordAuthenticationFilter 다음에 MoNewUserValidationFilter를 실행하도록 설정
+            .addFilterAfter(new MoNewUserValidationFilter(),
+                UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
@@ -58,14 +62,15 @@ public class SecurityConfig {
     // 수동 인증 시 사용할 AuthenticationManager Bean 등록
     // formLogin()을 사용하지 않기 때문에 -> 인증 직접 처리 위해 Bean 등록
     @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config)
+        throws Exception {
         return config.getAuthenticationManager();
     }
 
     @Bean
     public CorsFilter corsFilter() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowCredentials(true); //
+        config.setAllowCredentials(true); // 쿠키 포함 요청 허용
         config.setAllowedOriginPatterns(List.of("*"));
         config.setAllowedMethods(List.of("GET", "POST", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
@@ -74,5 +79,10 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return new CorsFilter(source);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/team03/monew/security/MoNewUserValidationFilter.java
+++ b/src/main/java/com/team03/monew/security/MoNewUserValidationFilter.java
@@ -29,11 +29,13 @@ public class MoNewUserValidationFilter extends OncePerRequestFilter {
         throws ServletException, IOException {
 
         // 1. 인증 정보 가져오기
+        // Authentication 객체 안에는 실제 인증된 사용자 정보 담겨 있음
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         log.info("[인가] 인증 정보 존재 여부: {}", authentication != null);
         log.info("[인가] 인증 여부: {}", authentication != null && authentication.isAuthenticated());
 
-        // 인증되지 않은 요청은 그대로 진행
+        // 인증되지 않은 요청은 다음 필터로 넘김
+        // 비로그인 이거나 인증되지 않은 사용자 일때
         if (authentication == null || !authentication.isAuthenticated()) {
             log.warn("[인가] 인증되지 않은 요청. 그대로 진행");
             filterChain.doFilter(request, response);
@@ -41,6 +43,7 @@ public class MoNewUserValidationFilter extends OncePerRequestFilter {
         }
 
         // 2. 사용자 ID 꺼내기
+        // Authentication 객체 안에 있는 principal를 꺼내서 CustomUserDetails 타입인지 검사
         Object principal = authentication.getPrincipal();
         if (!(principal instanceof CustomUserDetails userDetails)) {
             log.warn("[인가] 예상치 못한 Principal 타입. userDetails 아님.");


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #122 

---

## 📌 작업 개요
<!-- 어떤 작업을 했는지 간단하게 요약해주세요 -->
- 회원가입 및 로그인 시 비밀번호 해싱 처리 적용

---

## 🛠 작업 상세 내용
<!-- 주요 작업 내용을 리스트로 정리해주세요 -->
- BCryptPasswordEncoder를 이용한 비밀번호 해싱 적용
- 회원가입 시 비밀번호를 해시하여 DB에 저장하도록 수정
- 로그인 시 입력된 평문 비밀번호와 해시된 DB 비밀번호를 비교하도록 수정
- SecurityConfig에 PasswordEncoder Bean 등록
- UserServiceImpl에 PasswordEncoder 의존성 주입
- 기존 평문 비밀번호 비교 로직 제거

## 참고 캡쳐 
1. 비밀번호 해싱 처리가 정상적으로 되는걸 확인 
<img width="870" alt="스크린샷 2025-06-15 오후 4 30 53" src="https://github.com/user-attachments/assets/f4ca3a2d-025e-4f38-873a-35f978b997bb" />


2. 해싱 처리가 된 비밀번호로 user 테이블에 저장되는걸 확인
<img width="870" alt="스크린샷 2025-06-15 오후 4 31 36" src="https://github.com/user-attachments/assets/330a0fc3-b820-45f8-9a09-6d25fee6a64e" />

