### PR TITLE
Fix: Mongo 동기화를 위한 ActivityDocumentUpdater, UserServiceImpl 수정

### DIFF
--- a/src/main/java/com/team03/monew/service/UserServiceImpl.java
+++ b/src/main/java/com/team03/monew/service/UserServiceImpl.java
@@ -13,6 +13,7 @@ import com.team03.monew.exception.ExceptionType;
 //import com.team03.monew.repository.ActivityRepository;
 import com.team03.monew.repository.UserRepository;
 import com.team03.monew.security.CustomUserDetails;
+import com.team03.monew.service.activity.ActivityDocumentUpdater;
 import jakarta.servlet.http.HttpServletRequest;
 import java.security.Security;
 import java.util.UUID;
@@ -33,9 +34,9 @@ public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
     private final UserMapper userMapper;
-    //    private final ActivityRepository activityRepository;
     private final UserDetailsService userDetailsService;
     private final PasswordEncoder passwordEncoder;
+    private final ActivityDocumentUpdater activityDocumentUpdater;
 
     @Override
     public UserDto register(UserRegisterRequest request) {
@@ -74,6 +75,8 @@ public class UserServiceImpl implements UserService {
         }
 
         user.updateNickname(request.nickname());
+
+        activityDocumentUpdater.update(user.getId());
         return userMapper.toDto(user);
     }
 

--- a/src/main/java/com/team03/monew/service/activity/ActivityDocumentUpdater.java
+++ b/src/main/java/com/team03/monew/service/activity/ActivityDocumentUpdater.java
@@ -104,4 +104,20 @@ public class ActivityDocumentUpdater {
                 return activityRepository.save(newActivity);
             });
     }
+
+    public void update(UUID userId) {
+        User user = userRepository.findByIdAndDeletedFalse(userId).orElseThrow(() -> {
+            ErrorDetail detail = new ErrorDetail("UUID", "userId", userId.toString());
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND, detail, ExceptionType.USER);
+        });
+
+        Activity activity = activityRepository.findById(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND,
+                new ErrorDetail("UUID", "activity.userId", userId.toString()),
+                ExceptionType.USER));
+
+        activity.setNickname(user.getNickname());
+
+        activityRepository.save(activity);
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #이슈번호

---

## 📌 작업 개요
<!-- 어떤 작업을 했는지 간단하게 요약해주세요 -->
- 사용자의 닉네임 수정시, 활동내역에 수정사항이 적용되지 않는 버그 수정


---

## 🛠 작업 상세 내용
<!-- 주요 작업 내용을 리스트로 정리해주세요 -->
- ActivityDocumentUpdater내 update() 메서드 생성
- UserServiceImpl 내 updateNickname 메서드에 위에서 만든 update() 메서드 적용

