### PR TITLE
Fix: 구독 취소 시 활동 내역(Activity Document)에서도 구독 정보가 제거되도록 기능 수정

### DIFF
--- a/src/main/java/com/team03/monew/repository/SubscriptionRepository.java
+++ b/src/main/java/com/team03/monew/repository/SubscriptionRepository.java
@@ -31,4 +31,6 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, UUID
     List<Subscription> findByUserOrderByCreatedAtDesc(User user);
 
     void deleteByInterest(Interest interest);
+
+    List<Subscription> findSubscriptionsByInterest(Interest interest);
 }

--- a/src/main/java/com/team03/monew/service/activity/ActivityDocumentUpdater.java
+++ b/src/main/java/com/team03/monew/service/activity/ActivityDocumentUpdater.java
@@ -120,4 +120,32 @@ public class ActivityDocumentUpdater {
 
         activityRepository.save(activity);
     }
+
+    public void updateSubscription(UUID userId, SubscriptionDto updatedDto) {
+        Activity activity = getOrCreateActivity(userId);
+
+        List<SubscriptionDto> subscriptions = activity.getSubscriptions();
+
+        // 동일한 interestId를 가진 기존 항목을 찾아서 교체
+        for (int i = 0; i < subscriptions.size(); i++) {
+            if (subscriptions.get(i).interestId().equals(updatedDto.interestId())) {
+                subscriptions.set(i, updatedDto);
+                activityRepository.save(activity);
+                return;
+            }
+        }
+
+        // 기존에 없으면 추가 (안전장치)
+        subscriptions.add(updatedDto);
+        activityRepository.save(activity);
+    }
+
+    public void removeSubscription(UUID userId, UUID interestId) {
+        Activity activity = getOrCreateActivity(userId);
+
+        List<SubscriptionDto> subscriptions = activity.getSubscriptions();
+        subscriptions.removeIf(s -> s.interestId().equals(interestId));
+
+        activityRepository.save(activity);
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #이슈번호

---

## 📌 작업 개요
<!-- 어떤 작업을 했는지 간단하게 요약해주세요 -->
- 구독 취소 시 활동 내역(Activity Document)에서도 구독 정보가 제거되도록 기능 수정

---

## 🛠 작업 상세 내용
<!-- 주요 작업 내용을 리스트로 정리해주세요 -->
- InterestService.unsubscribe() 내에 활동 내역 동기화 코드 추가
- activityDocumentUpdater.removeSubscription(userId, interestId) 호출
- 기존 삭제 로직(관심사 삭제 시 동기화)과 일관성 유지
- MongoDB 활동 내역에서 구독 취소한 관심사 자동 제거 확인

